### PR TITLE
Phia clusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ orderly_envir.yml
 .DS_Store
 src/.DS_Store
 .orderly
+
+*~

--- a/orderly_config.yml
+++ b/orderly_config.yml
@@ -1,4 +1,11 @@
 remote:
+  fertility:
+    driver: orderly.sharepoint::orderly_remote_sharepoint
+    args:
+      url: https://imperiallondon.sharepoint.com
+      site: HIVInferenceGroup-WP
+      path: Shared Documents/orderly/fertility
+
   real:
     driver: orderly.sharepoint::orderly_remote_sharepoint
     args:
@@ -18,12 +25,6 @@ remote:
   #     url: https://imperiallondon.sharepoint.com
   #     site: HIVInferenceGroup-WP
   #     path: Shared Documents/orderly/mics
-  fertility:
-    driver: orderly.sharepoint::orderly_remote_sharepoint
-    args:
-      url: https://imperiallondon.sharepoint.com
-      site: HIVInferenceGroup-WP
-      path: Shared Documents/orderly/fertility
   malawi:
     driver: orderly.sharepoint::orderly_remote_sharepoint
     args:

--- a/src/civ_survey_phia/orderly.yml
+++ b/src/civ_survey_phia/orderly.yml
@@ -1,0 +1,35 @@
+script: script.R
+
+artefacts:
+  - data:
+      description: CIPHIA 2017 survey microdata
+      filenames:
+        - civ2017phia_survey_meta.csv
+        - civ2017phia_survey_regions.csv
+        - civ2017phia_survey_clusters.csv
+        - civ2017phia_survey_individuals.csv
+        - civ2017phia_survey_biomarker.csv
+        - civ2017phia_survey_circumcision.csv
+  - staticgraph:
+      description: Survey region boundaries
+      filenames:
+        - civ2017phia_survey-region-alignment.pdf
+
+packages:
+  - dplyr
+  - forcats
+  - ggplot2
+  - haven
+  - naomi
+  - spud
+  - rdhs
+  - readr
+  - sf
+  - tidyr
+
+depends:
+  civ_data_areas:
+    id: latest
+    use:
+      depends/civ_areas.geojson: civ_areas.geojson
+  

--- a/src/civ_survey_phia/script.R
+++ b/src/civ_survey_phia/script.R
@@ -1,0 +1,359 @@
+
+#' ## Survey meta data
+
+iso3 <- "CIV"
+country <- "Cote d'Ivoire"
+survey_id  <- "CIV2017PHIA"
+survey_mid_calendar_quarter <- "CY2017Q4"
+fieldwork_start <- NA
+fieldwork_end <- NA
+
+
+#' ## Load area hierarchy
+areas <- read_sf("depends/civ_areas.geojson")
+
+#' ## Load PHIA datasets
+sharepoint <- spud::sharepoint$new("https://imperiallondon.sharepoint.com/")
+
+phia_path <- "sites/HIVInferenceGroup-WP/Shared Documents/Data/household surveys/PHIA/datasets/CIV/datasets"
+
+paths <- list(geo = "CIPHIA 2017-2018 PR Geospatial Data 20210804.zip",
+              hh = "102 CIPHIA 2017-2018 Household Dataset (DTA).zip",
+              ind = "202 CIPHIA 2017-2018 Adult Interview Dataset (DTA).zip",
+              bio = "302 CIPHIA 2017-2018 Adult Biomarker Dataset (DTA).zip",
+              chind = "205 CIPHIA 2017-2018 Child Interview Dataset (DTA).zip",
+              chbio = "305 CIPHIA 2017-2018 Child Biomarker Dataset (DTA).zip") %>%
+  lapply(function(x) file.path(phia_path, x)) %>%
+  c(civ_gadm1 = "sites/HIVInferenceGroup-WP/Shared%20Documents/Data/shape%20files/gadm/v3.6/gadm36_CIV_1_sf.rds") %>%
+  lapply(URLencode)
+
+phia_files <- lapply(paths, sharepoint$download)
+
+geo <- rdhs::read_zipdata(phia_files$geo)
+
+hh <- rdhs::read_zipdata(phia_files$hh)
+bio <- rdhs::read_zipdata(phia_files$bio)
+ind <- rdhs::read_zipdata(phia_files$ind)
+chbio <- rdhs::read_zipdata(phia_files$chbio)
+chind <- rdhs::read_zipdata(phia_files$chind)
+
+
+#' Note: religion and ethnicity not asked
+
+phia <- ind %>%
+  filter(indstatus == 1) %>%  # Respondent
+  select(centroidid, district, urban, householdid,
+         personid, surveystyear, surveystmonth,
+         intwt0, gender, age,
+         mcstatus, mcage, mcwho) %>%
+  full_join(
+    bio %>%
+    filter(bt_status == 1) %>%
+    select(personid, btwt0, hivstatusfinal, arvstatus, artselfreported,
+           vls, cd4count, recentlagvlarv),
+    by = "personid"
+  ) %>%
+  mutate(survey_id = survey_id,
+         cluster_id = centroidid)
+
+chphia <- chind %>%
+  filter(indstatus == 1) %>%
+  select(centroidid, district, urban, householdid,
+         personid, surveystyear, surveystmonth,
+         intwt0, gender, age, agem) %>%
+  full_join(
+    chbio %>%
+    filter(bt_status == 1) %>%
+    select(personid, btwt0, hivstatusfinal, arvstatus, pedartparentreported,
+           vls, cd4count, recentlagvlarv),
+    by = "personid"
+  ) %>%
+  mutate(survey_id = survey_id,
+         cluster_id = centroidid)
+
+
+
+#' ## Survey regions
+#'
+#' This table identifies the smallest area in the area hierarchy which contains each
+#' region in the survey stratification, which is the smallest area to which a cluster
+#' can be assigned with certainty.
+
+hh$survey_region_id <- hh$district # different in each survey dataset depending on survey stratification
+
+survey_region_id <- c("Abidjan" = 1,
+                      "Yamoussoukro" = 2,
+                      "Bas-Sassandra" = 3,
+                      "Comoé" = 4,
+                      "Denguélé" = 5,
+                      "Gôh-Djiboua" = 6,
+                      "Lacs" = 7,
+                      "Lagunes" = 8,
+                      "Montagnes" = 9,
+                      "Sassandra-Marahoué" = 10,
+                      "Savanes" = 11,
+                      "Vallée du Bandama" = 12,
+                      "Woroba" = 13,
+                      "Zanzan" = 14)
+
+areas %>%
+  filter(area_level == 1) %>%
+  select(area_id, area_name) %>%
+  st_drop_geometry() %>%
+  print(n = Inf)
+
+civ_gadm1 <- readRDS(phia_files$civ_gadm1)
+
+survey_regions <- civ_gadm1 %>%
+  transmute(survey_id = survey_id,
+            survey_region_name = NAME_1,
+            survey_region_id = recode(survey_region_name, !!!survey_region_id)) %>%
+  st_as_sf()
+
+
+
+#' Allocate each area to survey region
+areas_wide <- naomi::spread_areas(areas)
+
+survey_region_areas <- survey_regions %>%
+  st_drop_geometry() %>%
+  full_join(
+    select(areas_wide, contains("area_id")) %>%
+    st_join(survey_regions, largest = TRUE)
+  )
+
+#' Check any unallocated areas
+stopifnot(nrow(filter(survey_region_areas, is.na(survey_region_id))) == 0)
+
+#' Check any survey regions with no areas
+stopifnot(nrow(filter(survey_region_areas, is.na(area_id))) == 0)
+
+p_survey_regions <- survey_region_areas %>%
+  st_as_sf() %>%
+  ggplot() +
+  geom_sf(aes(fill = survey_region_name), alpha = 0.7, size = 0.25, color = "grey60") +
+  geom_sf(data = civ_gadm1, fill = NA) +
+  th_map() +
+  ggtitle("Fill = aggregated health districts\nLines = GADM survey region boundaries")
+
+ggsave("civ2017phia_survey-region-alignment.pdf", p_survey_regions, h = 7, w = 8)
+
+#' Identify survey_region_area_id
+survey_regions <- survey_region_areas %>%
+  select(survey_id, survey_region_id, survey_region_name,
+         dplyr::matches("area_id[0-9]+")) %>%
+  gather(level, survey_region_area_id,
+         contains("area_id"), factor_key = TRUE) %>%
+  mutate(level = fct_rev(level)) %>%
+  distinct() %>%
+  group_by(survey_id, survey_region_id, level) %>%
+  filter(n() == 1) %>%
+  arrange(survey_id, survey_region_id, level) %>%
+  group_by(survey_id, survey_region_id) %>%
+  filter(row_number() == 1) %>%
+  ungroup() %>%
+  select(-level)
+
+
+#' *** Should not require edits beyond this point ***
+
+#' ## Survey clusters dataset
+#'
+#' This data frame maps survey clusters to the highest level in the area hiearchy
+#' based on geomasked cluster centroids, additionally checking that the geolocated
+#' areas are contained in the survey region.
+
+survey_clusters <- hh %>%
+  transmute(survey_id = survey_id,
+            cluster_id = centroidid,
+            cluster_id,
+            res_type = factor(urban, 1:2, c("urban", "rural")),
+            survey_region_id) %>%
+  distinct() %>%
+  left_join(geo, by = c("cluster_id" = "centroidid")) %>%
+  sf::st_as_sf(coords = c("longitude", "latitude"), remove = FALSE) %>%
+  sf::`st_crs<-`(4326)
+
+
+#' Snap clusters to areas
+#' 
+#' This is slow because it maps to the lowest level immediately
+#' It would be more efficient to do this recursively through
+#' the location hierarchy tree -- but not worth the effort right now.
+
+#' Create a list of all of the areas within each survey region
+#' (These are the candidate areas where a cluster could be located)
+
+survey_region_areas  <- survey_region_areas %>%
+  select(survey_region_id, area_id, geometry_area = geometry)
+
+#' Calculate distance to each candidate area for each cluster
+
+survey_clusters <- survey_clusters %>%
+  left_join(survey_region_areas, by = "survey_region_id") %>%
+  mutate(
+    distance = unlist(Map(sf::st_distance, geometry, geometry_area))
+  )
+
+#' Keep the area with the smallest distance from cluster centroid.
+#' (Should be 0 for almost all)
+
+survey_clusters <- survey_clusters %>%
+  arrange(distance) %>%
+  group_by(survey_id, cluster_id) %>%
+  filter(row_number() == 1) %>%
+  ungroup() %>%
+  as.data.frame() %>%
+  transmute(survey_id,
+            cluster_id,
+            res_type,
+            survey_region_id,
+            longitude,
+            latitude,
+            geoloc_area_id = area_id,
+            geoloc_distance = distance)
+
+#' Review clusters outside admin area
+
+survey_clusters %>%
+  filter(geoloc_distance > 0) %>%
+  arrange(-geoloc_distance) %>%
+  left_join(survey_regions) 
+
+#' ## Survey individuals dataset
+
+mcstatus_lables <- c(`1` = "Yes",
+                     `2` = "No",
+                     `-8` = "Don't know",
+                     `-9` = "Refused")
+
+mcwho_labels = c(`1` = "Doctor, clinical officer, or nurse",
+                 `2` = "Traditional practitioner / circumciser",
+                 `3` = "Midwife",
+                 `4` = "Family/Friend",
+                 `96` = "Other",
+                 `-8` = "Don't know",
+                 `-9` = "Refused")
+
+mcwho_recode = c(`1` = "Healthcare worker",
+                 `2` = "Traditional practitioner",
+                 `3` = "Traditional practitioner",   ## TODO: UNSURE ON THIS
+                 `4` = "Traditional practitioner",   ## TODO: UNSURE ON THIS
+                 `96` = "Traditional practitioner",
+                 `-8` = NA_character_,
+                 `-9` = NA_character_)
+
+
+#' Create individuals data
+
+survey_individuals <-
+  bind_rows(
+    phia %>%
+    transmute(
+      survey_id,
+      cluster_id,
+      individual_id = personid,
+      household = householdid,
+      line = personid,
+      interview_cmc = 12 * (surveystyear - 1900) + surveystmonth,
+      sex = factor(gender, 1:2, c("male", "female")),
+      age,
+      dob_cmc = NA,
+      indweight = intwt0
+    ),
+    chphia %>%
+    transmute(
+      survey_id,
+      cluster_id,
+      individual_id = personid,
+      household = householdid,
+      line = personid,
+      interview_cmc = 12 * (surveystyear - 1900) + surveystmonth,
+      sex = factor(gender, 1:2, c("male", "female")),
+      age,
+      dob_cmc = interview_cmc - agem,
+      indweight = intwt0
+    )
+  ) %>%
+  mutate(age = as.integer(age),
+         indweight = indweight / mean(indweight, na.rm=TRUE)) 
+
+
+survey_biomarker <-
+  bind_rows(
+    phia %>%
+    filter(!is.na(hivstatusfinal)) %>%
+    transmute(
+      survey_id,
+      individual_id = personid,
+      hivweight = btwt0,
+      hivstatus = case_when(hivstatusfinal == 1 ~ 1,
+                            hivstatusfinal == 2 ~ 0),
+      arv = case_when(arvstatus == 1 ~ 1,
+                      arvstatus == 2 ~ 0),
+      artself = case_when(artselfreported == 1 ~ 1,
+                          artselfreported == 2 ~ 0),
+      vls = case_when(vls == 1 ~ 1,
+                      vls == 2 ~ 0),
+      cd4 = cd4count,
+      recent = case_when(recentlagvlarv == 1 ~ 1,
+                         recentlagvlarv == 2 ~ 0)
+    )
+   ,
+    chphia %>%
+    filter(!is.na(hivstatusfinal)) %>%
+    transmute(
+      survey_id,
+      individual_id = personid,
+      hivweight = btwt0,
+      hivstatus = case_when(hivstatusfinal == 1 ~ 1,
+                            hivstatusfinal == 2 ~ 0),
+      arv = case_when(arvstatus == 1 ~ 1,
+                      arvstatus == 2 ~ 0),
+      artself = case_when(pedartparentreported == 1 ~ 1,
+                          pedartparentreported == 2 ~ 0),
+      vls = case_when(vls == 1 ~ 1,
+                      vls == 2 ~ 0),
+      cd4 = cd4count,
+      recent = case_when(recentlagvlarv == 1 ~ 1,
+                         recentlagvlarv == 2 ~ 0)
+    )
+  ) %>%
+  mutate(hivweight = hivweight / mean(hivweight, na.rm = TRUE))
+
+
+survey_circumcision <- phia %>%
+  filter(gender == 1) %>%
+  transmute(
+    survey_id,
+    individual_id = personid,
+    circumcised = recode(mcstatus, `2` = 0L , `1` = 1L, .default = NA_integer_),
+    circ_age = mcage,
+    circ_where = NA_character_,
+    circ_who = recode(mcwho, !!!mcwho_recode)
+  )
+
+
+
+survey_meta <- survey_individuals %>%
+  group_by(survey_id) %>%
+  summarise(female_age_min = min(if_else(sex == "female", age, NA_integer_), na.rm=TRUE),
+            female_age_max = max(if_else(sex == "female", age, NA_integer_), na.rm=TRUE),
+            male_age_min = min(if_else(sex == "male", age, NA_integer_), na.rm=TRUE),
+            male_age_max = max(if_else(sex == "male", age, NA_integer_), na.rm=TRUE),
+            .groups = "drop") %>%
+  mutate(iso3 = substr(survey_id, 1, 3),
+         country = country,
+         survey_type = "PHIA",
+         survey_mid_calendar_quarter = recode(iso3, "MWI" = survey_mid_calendar_quarter),
+         fieldwork_start = fieldwork_start,
+         fieldwork_end   = fieldwork_end)
+
+#' ## Save survey datasets
+
+write_csv(survey_meta, paste0(tolower(survey_id), "_survey_meta.csv"), na = "")
+write_csv(survey_regions, paste0(tolower(survey_id), "_survey_regions.csv"), na = "")
+write_csv(survey_clusters, paste0(tolower(survey_id), "_survey_clusters.csv"), na = "")
+write_csv(survey_individuals, paste0(tolower(survey_id), "_survey_individuals.csv"), na = "")
+write_csv(survey_biomarker, paste0(tolower(survey_id), "_survey_biomarker.csv"), na = "")
+write_csv(survey_circumcision, paste0(tolower(survey_id), "_survey_circumcision.csv"), na = "")

--- a/src/cmr_survey_phia/orderly.yml
+++ b/src/cmr_survey_phia/orderly.yml
@@ -1,0 +1,29 @@
+script: script.R
+
+artefacts:
+  - data:
+      description: CamPHIA 2017 survey microdata
+      filenames:
+        - cmr2017phia_survey_meta.csv
+        - cmr2017phia_survey_regions.csv
+        - cmr2017phia_survey_clusters.csv
+        - cmr2017phia_survey_individuals.csv
+        - cmr2017phia_survey_biomarker.csv
+        - cmr2017phia_survey_circumcision.csv
+
+packages:
+  - dplyr
+  - ggplot2
+  - haven
+  - naomi
+  - spud
+  - rdhs
+  - readr
+  - sf
+
+depends:
+  cmr_data_areas:
+    id: latest
+    use:
+      depends/cmr_areas.geojson: cmr_areas.geojson
+  

--- a/src/cmr_survey_phia/script.R
+++ b/src/cmr_survey_phia/script.R
@@ -1,0 +1,377 @@
+
+#' ## Survey meta data
+
+iso3 <- "CMR"
+country <- "Cameroon"
+survey_id  <- "CMR2017PHIA"
+survey_mid_calendar_quarter <- "CY2017Q3"
+fieldwork_start <- NA
+fieldwork_end <- NA
+
+
+#' ## Load area hierarchy
+areas <- read_sf("depends/cmr_areas.geojson")
+
+#' ## Load PHIA datasets
+sharepoint <- spud::sharepoint$new("https://imperiallondon.sharepoint.com/")
+
+phia_path <- "sites/HIVInferenceGroup-WP/Shared Documents/Data/household surveys/PHIA/datasets/CMR/datasets"
+
+paths <- list(geo = "CAMPHIA 2017-2018 PR Geospatial Data 20210628.zip",
+              hh = "102 CAMPHIA 2017-2018 Household Dataset (DTA).zip",
+              ind = "202 CAMPHIA 2017-2018 Adult Interview Dataset (DTA).zip",
+              bio = "302 CAMPHIA 2017-2018 Adult Biomarker Dataset (DTA).zip",
+              chind = "205 CAMPHIA 2017-2018 Child Interview Dataset (DTA).zip",
+              chbio = "305 CAMPHIA 2017-2018 Child Biomarker Dataset (DTA).zip") %>%
+  lapply(function(x) file.path(phia_path, x)) %>%
+  lapply(URLencode)
+
+phia_files <- lapply(paths, sharepoint$download)
+
+geo <- rdhs::read_zipdata(phia_files$geo)
+
+hh <- rdhs::read_zipdata(phia_files$hh)
+bio <- rdhs::read_zipdata(phia_files$bio)
+ind <- rdhs::read_zipdata(phia_files$ind)
+chbio <- rdhs::read_zipdata(phia_files$chbio)
+chind <- rdhs::read_zipdata(phia_files$chind)
+
+
+phia <- ind %>%
+  filter(indstatus == 1) %>%  # Respondent
+  select(centroidid, region, urban, householdid,
+         personid, surveystyear, surveystmonth,
+         intwt0, gender, age, religion, ethnic,
+         mcstatus, mcage, mcwho) %>%
+  full_join(
+    bio %>%
+    filter(bt_status == 1) %>%
+    select(personid, btwt0, hivstatusfinal, arvstatus, artselfreported,
+           vls, cd4count, recentlagvlarv),
+    by = "personid"
+  ) %>%
+  mutate(survey_id = survey_id,
+         cluster_id = centroidid)
+
+chphia <- chind %>%
+  filter(indstatus == 1) %>%
+  select(centroidid, region, urban, householdid,
+         personid, surveystyear, surveystmonth,
+         intwt0, gender, age, agem) %>%
+  full_join(
+    chbio %>%
+    filter(bt_status == 1) %>%
+    select(personid, btwt0, hivstatusfinal, arvstatus, pedartparentreported,
+           vls, cd4count, recentlagvlarv),
+    by = "personid"
+  ) %>%
+  mutate(survey_id = survey_id,
+         cluster_id = centroidid)
+
+
+
+#' ## Survey regions
+#'
+#' This table identifies the smallest area in the area hierarchy which contains each
+#' region in the survey stratification, which is the smallest area to which a cluster
+#' can be assigned with certainty.
+
+hh$survey_region_id <- hh$region # different in each survey dataset depending on survey stratification
+
+survey_region_id <- c("Adamaoua" = 1,
+                      "Centre" = 2,
+                      "Douala" = 3,
+                      "Est" = 4,
+                      "Extreme-Nord" = 5,
+                      "Littoral" = 6,
+                      "Nord" = 7,
+                      "Nord-Ouest" = 8,
+                      "Sud" = 9,
+                      "Sud-Ouest" = 10,
+                      "Ouest" = 11,
+                      "Yaounde" = 12)
+
+
+areas %>%
+  filter(area_level == 1) %>%
+  select(area_id, area_name) %>%
+  st_drop_geometry() %>%
+  print(n = Inf)
+
+areas_recode <- areas %>%
+  mutate(area_name = recode(area_name,
+                            "Centre (sans Yaoundé)" = "Centre",
+                            "Extreme Nord" = "Extreme-Nord",
+                            "Littoral (sans Douala)" = "Littoral",
+                            "Yaoundé" = "Yaounde"))
+
+survey_regions <- areas_recode %>%
+  filter(area_level == 1) %>%
+  st_drop_geometry() %>%
+  select(survey_region_area_id = area_id, survey_region_name = area_name) %>%
+  left_join(tibble(survey_id = survey_id,
+                    survey_region_id = survey_region_id,
+                   survey_region_name = names(survey_region_id)))
+
+survey_regions %>%
+  print(n = Inf)
+
+#' Add survey region boundary
+
+survey_regions <- survey_regions %>%
+  left_join(
+    areas %>% select(survey_region_area_id = area_id),
+    by = "survey_region_area_id"
+  ) %>%
+  st_as_sf()
+
+#' Inspect area_id assigments to confirm
+
+survey_regions %>%
+  left_join(
+    areas %>%
+    as.data.frame() %>%
+    select(area_id, area_name, area_level, area_level_label),
+    by = c("survey_region_area_id" = "area_id")
+  )
+
+
+#' *** Should not require edits beyond this point ***
+
+#' ## Survey clusters dataset
+#'
+#' This data frame maps survey clusters to the highest level in the area hiearchy
+#' based on geomasked cluster centroids, additionally checking that the geolocated
+#' areas are contained in the survey region.
+
+survey_clusters <- hh %>%
+  transmute(survey_id = survey_id,
+            cluster_id = centroidid,
+            cluster_id,
+            res_type = factor(urban, 1:2, c("urban", "rural")),
+            survey_region_id) %>%
+  distinct() %>%
+  left_join(geo, by = c("cluster_id" = "centroidid")) %>%
+  sf::st_as_sf(coords = c("longitude", "latitude"), remove = FALSE) %>%
+  sf::`st_crs<-`(4326)
+
+
+#' Snap clusters to areas
+#' 
+#' This is slow because it maps to the lowest level immediately
+#' It would be more efficient to do this recursively through
+#' the location hierarchy tree -- but not worth the effort right now.
+
+#' Create a list of all of the areas within each survey region
+#' (These are the candidate areas where a cluster could be located)
+
+survey_region_areas  <- survey_regions %>%
+  st_join(
+    st_point_on_surface(areas) %>%
+    filter(area_level == max(area_level)) %>%
+    select(area_id)
+  ) %>%
+  st_set_geometry(NULL) %>%
+  left_join(
+    areas %>% select(area_id, geometry),
+    by = "area_id"
+  ) %>%
+  select(survey_region_id, area_id, geometry_area = geometry)
+
+#' Calculate distance to each candidate area for each cluster
+
+survey_clusters <- survey_clusters %>%
+  left_join(survey_region_areas, by = "survey_region_id") %>%
+  mutate(
+    distance = unlist(Map(sf::st_distance, geometry, geometry_area))
+  )
+
+#' Keep the area with the smallest distance from cluster centroid.
+#' (Should be 0 for almost all)
+
+survey_clusters <- survey_clusters %>%
+  arrange(distance) %>%
+  group_by(survey_id, cluster_id) %>%
+  filter(row_number() == 1) %>%
+  ungroup() %>%
+  as.data.frame() %>%
+  transmute(survey_id,
+            cluster_id,
+            res_type,
+            survey_region_id,
+            longitude,
+            latitude,
+            geoloc_area_id = area_id,
+            geoloc_distance = distance)
+
+#' Review clusters outside admin area
+
+survey_clusters %>%
+  filter(geoloc_distance > 0) %>%
+  arrange(-geoloc_distance) %>%
+  left_join(survey_regions) 
+
+#' ## Survey individuals dataset
+
+religion_labels <- c(`1` = "Catholic",
+                     `2` = "Protestant",
+                     `3` = "Muslim",
+                     `4` = "Animist",
+                     `5` = "Other Christian",
+                     `6` = "No Religion",
+                     `96` = "Other (Specify)",
+                     `-8` = "Don’t Know",
+                     `-9` = "Refused")
+
+ethnic_labels <- c(`1` = "Arabes-Choa/Peulh/Haoussa",
+                   `2` = "Biu-Mandara",
+                   `3` = "Adamaoua-Oubangui",
+                   `4` = "Bantoïde Sud-Ouest",
+                   `5` = "Grassfields",
+                   `6` = "Bamilike/Bamoun",
+                   `7` = "Côtier/Ngoe/Oroko",
+                   `8` = "Beti/Bassa/Mbam",
+                   `9` = "Kako/Meka/Pygmé",
+                   `10` = "Foreigner",
+                   `11` = "No Tribe",
+                   `96` = "Other (Specify)",
+                   `-8` = "Don’t Know",
+                   `-9` = "Refused")
+
+mcstatus_lables <- c(`1` = "Yes",
+                     `2` = "No",
+                     `-8` = "Don't know",
+                     `-9` = "Refused")
+
+mcwho_labels = c(`1` = "Doctor, clinical officer, or nurse",
+                 `2` = "Traditional practitioner / circumciser",
+                 `3` = "Midwife",
+                 `4` = "Family/Friend",
+                 `96` = "Other",
+                 `-8` = "Don't know",
+                 `-9` = "Refused")
+
+mcwho_recode = c(`1` = "Healthcare worker",
+                 `2` = "Traditional practitioner",
+                 `3` = "Traditional practitioner",   ## TODO: UNSURE ON THIS
+                 `4` = "Traditional practitioner",   ## TODO: UNSURE ON THIS
+                 `96` = "Traditional practitioner",
+                 `-8` = NA_character_,
+                 `-9` = NA_character_)
+
+
+#' Create individuals data
+
+survey_individuals <-
+  bind_rows(
+    phia %>%
+    transmute(
+      survey_id,
+      cluster_id,
+      individual_id = personid,
+      household = householdid,
+      line = personid,
+      interview_cmc = 12 * (surveystyear - 1900) + surveystmonth,
+      sex = factor(gender, 1:2, c("male", "female")),
+      age,
+      dob_cmc = NA,
+      religion = recode(religion, !!!religion_labels),
+      ethnicity = recode(ethnic, !!!ethnic_labels),
+      indweight = intwt0
+    ),
+    chphia %>%
+    transmute(
+      survey_id,
+      cluster_id,
+      individual_id = personid,
+      household = householdid,
+      line = personid,
+      interview_cmc = 12 * (surveystyear - 1900) + surveystmonth,
+      sex = factor(gender, 1:2, c("male", "female")),
+      age,
+      dob_cmc = interview_cmc - agem,
+      indweight = intwt0
+    )
+  ) %>%
+  mutate(age = as.integer(age),
+         indweight = indweight / mean(indweight, na.rm=TRUE)) 
+
+
+survey_biomarker <-
+  bind_rows(
+    phia %>%
+    filter(!is.na(hivstatusfinal)) %>%
+    transmute(
+      survey_id,
+      individual_id = personid,
+      hivweight = btwt0,
+      hivstatus = case_when(hivstatusfinal == 1 ~ 1,
+                            hivstatusfinal == 2 ~ 0),
+      arv = case_when(arvstatus == 1 ~ 1,
+                      arvstatus == 2 ~ 0),
+      artself = case_when(artselfreported == 1 ~ 1,
+                          artselfreported == 2 ~ 0),
+      vls = case_when(vls == 1 ~ 1,
+                      vls == 2 ~ 0),
+      cd4 = cd4count,
+      recent = case_when(recentlagvlarv == 1 ~ 1,
+                         recentlagvlarv == 2 ~ 0)
+    )
+   ,
+    chphia %>%
+    filter(!is.na(hivstatusfinal)) %>%
+    transmute(
+      survey_id,
+      individual_id = personid,
+      hivweight = btwt0,
+      hivstatus = case_when(hivstatusfinal == 1 ~ 1,
+                            hivstatusfinal == 2 ~ 0),
+      arv = case_when(arvstatus == 1 ~ 1,
+                      arvstatus == 2 ~ 0),
+      artself = case_when(pedartparentreported == 1 ~ 1,
+                          pedartparentreported == 2 ~ 0),
+      vls = case_when(vls == 1 ~ 1,
+                      vls == 2 ~ 0),
+      cd4 = cd4count,
+      recent = case_when(recentlagvlarv == 1 ~ 1,
+                         recentlagvlarv == 2 ~ 0)
+    )
+  ) %>%
+  mutate(hivweight = hivweight / mean(hivweight, na.rm = TRUE))
+
+
+survey_circumcision <- phia %>%
+  filter(gender == 1) %>%
+  transmute(
+    survey_id,
+    individual_id = personid,
+    circumcised = recode(mcstatus, `2` = 0L , `1` = 1L, .default = NA_integer_),
+    circ_age = mcage,
+    circ_where = NA_character_,
+    circ_who = recode(mcwho, !!!mcwho_recode)
+  )
+
+
+
+survey_meta <- survey_individuals %>%
+  group_by(survey_id) %>%
+  summarise(female_age_min = min(if_else(sex == "female", age, NA_integer_), na.rm=TRUE),
+            female_age_max = max(if_else(sex == "female", age, NA_integer_), na.rm=TRUE),
+            male_age_min = min(if_else(sex == "male", age, NA_integer_), na.rm=TRUE),
+            male_age_max = max(if_else(sex == "male", age, NA_integer_), na.rm=TRUE),
+            .groups = "drop") %>%
+  mutate(iso3 = substr(survey_id, 1, 3),
+         country = country,
+         survey_type = "PHIA",
+         survey_mid_calendar_quarter = recode(iso3, "MWI" = survey_mid_calendar_quarter),
+         fieldwork_start = fieldwork_start,
+         fieldwork_end   = fieldwork_end)
+
+#' ## Save survey datasets
+
+write_csv(survey_meta, paste0(tolower(survey_id), "_survey_meta.csv"), na = "")
+write_csv(survey_regions, paste0(tolower(survey_id), "_survey_regions.csv"), na = "")
+write_csv(survey_clusters, paste0(tolower(survey_id), "_survey_clusters.csv"), na = "")
+write_csv(survey_individuals, paste0(tolower(survey_id), "_survey_individuals.csv"), na = "")
+write_csv(survey_biomarker, paste0(tolower(survey_id), "_survey_biomarker.csv"), na = "")
+write_csv(survey_circumcision, paste0(tolower(survey_id), "_survey_circumcision.csv"), na = "")

--- a/src/lso_survey_phia/orderly.yml
+++ b/src/lso_survey_phia/orderly.yml
@@ -1,0 +1,29 @@
+script: script.R
+
+artefacts:
+  - data:
+      description: LePHIA 2016-17 survey microdata
+      filenames:
+        - lso2017phia_survey_meta.csv
+        - lso2017phia_survey_regions.csv
+        - lso2017phia_survey_clusters.csv
+        - lso2017phia_survey_individuals.csv
+        - lso2017phia_survey_biomarker.csv
+        - lso2017phia_survey_circumcision.csv
+
+packages:
+  - dplyr
+  - ggplot2
+  - haven
+  - naomi
+  - spud
+  - rdhs
+  - readr
+  - sf
+
+depends:
+  lso_data_areas:
+    id: latest
+    use:
+      depends/lso_areas.geojson: lso_areas.geojson
+  

--- a/src/lso_survey_phia/script.R
+++ b/src/lso_survey_phia/script.R
@@ -1,0 +1,362 @@
+
+#' ## Survey meta data
+
+iso3 <- "LSO"
+country <- "Lesotho"
+survey_id  <- "LSO2017PHIA"
+survey_mid_calendar_quarter <- "CY2017Q4"
+fieldwork_start <- NA
+fieldwork_end <- NA
+
+
+#' ## Load area hierarchy
+areas <- read_sf("depends/lso_areas.geojson")
+
+
+#' ## Load PHIA datasets
+sharepoint <- spud::sharepoint$new("https://imperiallondon.sharepoint.com/")
+
+phia_path <- "sites/HIVInferenceGroup-WP/Shared Documents/Data/household surveys/PHIA/datasets/LSO/datasets"
+
+paths <- list(geo = "LePHIA 2016-2017 PR Geospatial Data 20210518.zip",
+              hh = "102_LePHIA 2016-2017 Household Dataset (DTA).zip",
+              ind = "202_LePHIA 2016-2017 Adult Interview Dataset (DTA).zip",
+              bio = "302_LePHIA 2016-2017 Adult Biomarker Dataset (DTA).zip",
+              chind = "205_LePHIA 2016-2017 Child Interview Dataset (DTA).zip",
+              chbio = "305_LePHIA 2016-2017 Child Biomarker Dataset (DTA).zip") %>%
+  lapply(function(x) file.path(phia_path, x)) %>%
+  lapply(URLencode)
+
+phia_files <- lapply(paths, sharepoint$download)
+
+geo <- rdhs::read_zipdata(phia_files$geo)
+
+hh <- rdhs::read_zipdata(phia_files$hh)
+bio <- rdhs::read_zipdata(phia_files$bio)
+ind <- rdhs::read_zipdata(phia_files$ind)
+chbio <- rdhs::read_zipdata(phia_files$chbio)
+chind <- rdhs::read_zipdata(phia_files$chind)
+
+phia <- ind %>%
+  filter(indstatus == 1) %>%  # Respondent
+  select(varstrat, varunit, district, urban, householdid,
+         personid, surveystyear, surveystmonth,
+         intwt0, gender, age, religion,
+         mcstatus, mcage, mcwho) %>%
+  full_join(
+    bio %>%
+    filter(bt_status == 1) %>%
+    select(personid, btwt0, hivstatusfinal, arvstatus, artselfreported,
+           vls, cd4count, recentlagvlarv),
+    by = "personid"
+  ) %>%
+  mutate(survey_id = survey_id,
+         cluster_id = paste(varstrat, varunit))
+
+
+#' Note: Religion was not asked for children. Strategy to
+#'       assign these based on `momid` if available, otherwise modal value
+#'       from the household. But the primary motivation for these variables
+#'       is for circumcision analysis, which is not asked for children.
+#' 
+
+chphia <- chind %>%
+  filter(indstatus == 1) %>%
+  select(varstrat, varunit, district, urban, householdid,
+         personid, surveystyear, surveystmonth,
+         intwt0, gender, age, agem) %>%
+  full_join(
+    chbio %>%
+    filter(bt_status == 1) %>%
+    select(personid, btwt0, hivstatusfinal, arvstatus, pedartparentreported,
+           vls, cd4count, recentlagvlarv),
+    by = "personid"
+  ) %>%
+  mutate(survey_id = survey_id,
+         cluster_id = paste(varstrat, varunit))
+
+
+
+#' ## Survey regions
+#'
+#' This table identifies the smallest area in the area hierarchy which contains each
+#' region in the survey stratification, which is the smallest area to which a cluster
+#' can be assigned with certainty.
+
+hh$survey_region_id <- hh$district # different in each survey dataset depending on survey stratification
+
+survey_region_id <- c("Maseru" = 1,
+                      "Mafeteng" = 2,
+                      "Mohale’s Hoek" = 3,
+                      "Leribe" = 4,
+                      "Berea" = 5,
+                      "Quthing" = 6,
+                      "Butha-Buthe" = 7,
+                      "Mokhotlong" = 8,
+                      "Qacha’s Nek" = 9,
+                      "Thaba-Tseka" = 10)
+
+areas %>% filter(area_level == 1) %>% select(area_id, area_name)
+
+
+survey_region_area_id <- c("Maseru" = "LSO_1_1",
+                           "Mafeteng" = "LSO_1_5",
+                           "Mohale’s Hoek" = "LSO_1_6",
+                           "Leribe" = "LSO_1_3",
+                           "Berea" = "LSO_1_4",
+                           "Quthing" = "LSO_1_7",
+                           "Butha-Buthe" = "LSO_1_2",
+                           "Mokhotlong" = "LSO_1_9",
+                           "Qacha’s Nek" = "LSO_1_8",
+                           "Thaba-Tseka" = "LSO_1_10")
+
+survey_regions <- tibble(survey_id = survey_id,
+                         survey_region_id = survey_region_id,
+                         survey_region_name = names(survey_region_id),
+                         survey_region_area_id = survey_region_area_id[names(survey_region_id)])
+
+
+#' Add survey region boundary
+
+survey_regions <- survey_regions %>%
+  left_join(
+    areas %>% select(survey_region_area_id = area_id)
+  ) %>%
+  st_as_sf()
+
+
+#' Inspect area_id assigments to confirm
+
+survey_regions %>%
+  left_join(
+    areas %>%
+    as.data.frame() %>%
+    select(area_id, area_name, area_level, area_level_label),
+    by = c("survey_region_area_id" = "area_id")
+  )
+
+
+#' *** Should not require edits beyond this point ***
+
+#' ## Survey clusters dataset
+#'
+#' This data frame maps survey clusters to the highest level in the area hiearchy
+#' based on geomasked cluster centroids, additionally checking that the geolocated
+#' areas are contained in the survey region.
+
+survey_clusters <- hh %>%
+  transmute(survey_id = survey_id,
+            cluster_id = paste(varstrat, varunit),
+            cluster_id,
+            res_type = factor(urban, 1:2, c("urban", "rural")),
+            survey_region_id,
+            centroidid) %>%
+  distinct() %>%
+  left_join(geo, by = "centroidid") %>%
+  select(-centroidid) %>%
+  sf::st_as_sf(coords = c("longitude", "latitude"), remove = FALSE) %>%
+  sf::`st_crs<-`(4326)
+
+
+#' Snap clusters to areas
+#' 
+#' This is slow because it maps to the lowest level immediately
+#' It would be more efficient to do this recursively through
+#' the location hierarchy tree -- but not worth the effort right now.
+
+#' Create a list of all of the areas within each survey region
+#' (These are the candidate areas where a cluster could be located)
+
+survey_region_areas  <- survey_regions %>%
+  st_join(
+    st_point_on_surface(areas) %>%
+    filter(area_level == max(area_level)) %>%
+    select(area_id)
+  ) %>%
+  st_set_geometry(NULL) %>%
+  left_join(
+    areas %>% select(area_id, geometry),
+    by = "area_id"
+  ) %>%
+  select(survey_region_id, area_id, geometry_area = geometry)
+
+#' Calculate distance to each candidate area for each cluster
+
+survey_clusters <- survey_clusters %>%
+  left_join(survey_region_areas, by = "survey_region_id") %>%
+  mutate(
+    distance = unlist(Map(sf::st_distance, geometry, geometry_area))
+  )
+
+#' Keep the area with the smallest distance from cluster centroid.
+#' (Should be 0 for almost all)
+
+survey_clusters <- survey_clusters %>%
+  arrange(distance) %>%
+  group_by(survey_id, cluster_id) %>%
+  filter(row_number() == 1) %>%
+  ungroup() %>%
+  as.data.frame() %>%
+  transmute(survey_id,
+            cluster_id,
+            res_type,
+            survey_region_id,
+            longitude,
+            latitude,
+            geoloc_area_id = area_id,
+            geoloc_distance = distance)
+
+#' Review clusters outside admin area
+
+survey_clusters %>%
+  filter(geoloc_distance > 0) %>%
+  arrange(-geoloc_distance) %>%
+  left_join(survey_regions) 
+
+
+
+#' ## Survey individuals dataset
+
+religion_labels <- c(`1` = "Roman Catholic",
+                     `2` = "Lesotho Evangelical",
+                     `3` = "Anglican",
+                     `4` = "Pentacostal",
+                     `5` = "Other Christian",
+                     `96` = "Other",
+                     `-8` = "Don't know",
+                     `-9` = "Refused")
+
+mcstatus_lables <- c(`1` = "Yes",
+                     `2` = "No",
+                     `-8` = "Don't know",
+                     `-9` = "Refused")
+
+mcwho_labels = c(`1` = "Doctor, clinical officer, or nurse",
+                 `2` = "Traditional practitioner / circumciser",
+                 `3` = "Midwife",
+                 `96` = "Other",
+                 `-8` = "Don't know",
+                 `-9` = "Refused")
+
+mcwho_recode = c(`1` = "Healthcare worker",
+                 `2` = "Traditional practitioner",
+                 `3` = "Traditional practitioner",   ## TODO: UNSURE ON THIS
+                 `96` = "Traditional practitioner",
+                 `-8` = NA_character_,
+                 `-9` = NA_character_)
+
+
+#' Create individuals data
+
+survey_individuals <-
+  bind_rows(
+    phia %>%
+    transmute(
+      survey_id,
+      cluster_id,
+      individual_id = personid,
+      household = householdid,
+      line = personid,
+      interview_cmc = 12 * (surveystyear - 1900) + surveystmonth,
+      sex = factor(gender, 1:2, c("male", "female")),
+      age,
+      dob_cmc = NA,
+      religion = recode(religion, !!!religion_labels),
+      indweight = intwt0
+    ),
+    chphia %>%
+    transmute(
+      survey_id,
+      cluster_id,
+      individual_id = personid,
+      household = householdid,
+      line = personid,
+      interview_cmc = 12 * (surveystyear - 1900) + surveystmonth,
+      sex = factor(gender, 1:2, c("male", "female")),
+      age,
+      dob_cmc = interview_cmc - agem,
+      indweight = intwt0
+    )
+  ) %>%
+  mutate(age = as.integer(age),
+         indweight = indweight / mean(indweight, na.rm=TRUE)) 
+
+
+survey_biomarker <-
+  bind_rows(
+    phia %>%
+    filter(!is.na(hivstatusfinal)) %>%
+    transmute(
+      survey_id,
+      individual_id = personid,
+      hivweight = btwt0,
+      hivstatus = case_when(hivstatusfinal == 1 ~ 1,
+                            hivstatusfinal == 2 ~ 0),
+      arv = case_when(arvstatus == 1 ~ 1,
+                      arvstatus == 2 ~ 0),
+      artself = case_when(artselfreported == 1 ~ 1,
+                          artselfreported == 2 ~ 0),
+      vls = case_when(vls == 1 ~ 1,
+                      vls == 2 ~ 0),
+      cd4 = cd4count,
+      recent = case_when(recentlagvlarv == 1 ~ 1,
+                         recentlagvlarv == 2 ~ 0)
+    )
+   ,
+    chphia %>%
+    filter(!is.na(hivstatusfinal)) %>%
+    transmute(
+      survey_id,
+      individual_id = personid,
+      hivweight = btwt0,
+      hivstatus = case_when(hivstatusfinal == 1 ~ 1,
+                            hivstatusfinal == 2 ~ 0),
+      arv = case_when(arvstatus == 1 ~ 1,
+                      arvstatus == 2 ~ 0),
+      artself = case_when(pedartparentreported == 1 ~ 1,
+                          pedartparentreported == 2 ~ 0),
+      vls = case_when(vls == 1 ~ 1,
+                      vls == 2 ~ 0),
+      cd4 = cd4count,
+      recent = case_when(recentlagvlarv == 1 ~ 1,
+                         recentlagvlarv == 2 ~ 0)
+    )
+  ) %>%
+  mutate(hivweight = hivweight / mean(hivweight, na.rm = TRUE))
+
+
+survey_circumcision <- phia %>%
+  filter(gender == 1) %>%
+  transmute(
+    survey_id,
+    individual_id = personid,
+    circumcised = recode(mcstatus, `2` = 0L , `1` = 1L, .default = NA_integer_),
+    circ_age = mcage,
+    circ_where = NA_character_,
+    circ_who = recode(mcwho, !!!mcwho_recode)
+  )
+
+
+
+survey_meta <- survey_individuals %>%
+  group_by(survey_id) %>%
+  summarise(female_age_min = min(if_else(sex == "female", age, NA_integer_), na.rm=TRUE),
+            female_age_max = max(if_else(sex == "female", age, NA_integer_), na.rm=TRUE),
+            male_age_min = min(if_else(sex == "male", age, NA_integer_), na.rm=TRUE),
+            male_age_max = max(if_else(sex == "male", age, NA_integer_), na.rm=TRUE),
+            .groups = "drop") %>%
+  mutate(iso3 = substr(survey_id, 1, 3),
+         country = country,
+         survey_type = "PHIA",
+         survey_mid_calendar_quarter = recode(iso3, "MWI" = survey_mid_calendar_quarter),
+         fieldwork_start = fieldwork_start,
+         fieldwork_end   = fieldwork_end)
+
+#' ## Save survey datasets
+
+write_csv(survey_meta, paste0(tolower(survey_id), "_survey_meta.csv"), na = "")
+write_csv(survey_regions, paste0(tolower(survey_id), "_survey_regions.csv"), na = "")
+write_csv(survey_clusters, paste0(tolower(survey_id), "_survey_clusters.csv"), na = "")
+write_csv(survey_individuals, paste0(tolower(survey_id), "_survey_individuals.csv"), na = "")
+write_csv(survey_biomarker, paste0(tolower(survey_id), "_survey_biomarker.csv"), na = "")
+write_csv(survey_circumcision, paste0(tolower(survey_id), "_survey_circumcision.csv"), na = "")

--- a/src/lso_survey_phia/script.R
+++ b/src/lso_survey_phia/script.R
@@ -39,7 +39,7 @@ chind <- rdhs::read_zipdata(phia_files$chind)
 
 phia <- ind %>%
   filter(indstatus == 1) %>%  # Respondent
-  select(varstrat, varunit, district, urban, householdid,
+  select(centroidid, district, urban, householdid,
          personid, surveystyear, surveystmonth,
          intwt0, gender, age, religion,
          mcstatus, mcage, mcwho) %>%
@@ -51,7 +51,7 @@ phia <- ind %>%
     by = "personid"
   ) %>%
   mutate(survey_id = survey_id,
-         cluster_id = paste(varstrat, varunit))
+         cluster_id = centroidid)
 
 
 #' Note: Religion was not asked for children. Strategy to
@@ -62,7 +62,7 @@ phia <- ind %>%
 
 chphia <- chind %>%
   filter(indstatus == 1) %>%
-  select(varstrat, varunit, district, urban, householdid,
+  select(centroidid, district, urban, householdid,
          personid, surveystyear, surveystmonth,
          intwt0, gender, age, agem) %>%
   full_join(
@@ -73,7 +73,7 @@ chphia <- chind %>%
     by = "personid"
   ) %>%
   mutate(survey_id = survey_id,
-         cluster_id = paste(varstrat, varunit))
+         cluster_id = centroidid)
 
 
 
@@ -146,14 +146,12 @@ survey_regions %>%
 
 survey_clusters <- hh %>%
   transmute(survey_id = survey_id,
-            cluster_id = paste(varstrat, varunit),
+            cluster_id = centroidid,
             cluster_id,
             res_type = factor(urban, 1:2, c("urban", "rural")),
-            survey_region_id,
-            centroidid) %>%
+            survey_region_id) %>%
   distinct() %>%
-  left_join(geo, by = "centroidid") %>%
-  select(-centroidid) %>%
+  left_join(geo, by = c("cluster_id" = "centroidid")) %>%
   sf::st_as_sf(coords = c("longitude", "latitude"), remove = FALSE) %>%
   sf::`st_crs<-`(4326)
 

--- a/src/mwi_survey_phia/orderly.yml
+++ b/src/mwi_survey_phia/orderly.yml
@@ -1,0 +1,33 @@
+script: script.R
+
+artefacts:
+  - data:
+      description: MPHIA 2015-16 survey microdata
+      filenames:
+        - mwi2016phia_survey_meta.csv
+        - mwi2016phia_survey_regions.csv
+        - mwi2016phia_survey_clusters.csv
+        - mwi2016phia_survey_individuals.csv
+        - mwi2016phia_survey_biomarker.csv
+        - mwi2016phia_survey_circumcision.csv
+  - staticgraph:
+      description: Comparison of MPHIA survey regions and health zones
+      filenames: 
+        - check/compare_survey_regions.png
+
+packages:
+  - dplyr
+  - ggplot2
+  - haven
+  - naomi
+  - spud
+  - rdhs
+  - readr
+  - sf
+
+depends:
+  mwi_data_areas:
+    id: latest
+    use:
+      depends/mwi_areas.geojson: mwi_areas.geojson
+  

--- a/src/mwi_survey_phia/script.R
+++ b/src/mwi_survey_phia/script.R
@@ -58,7 +58,7 @@ phia <- ind %>%
 
 chphia <- chind %>%
   filter(indstatus == 1) %>%
-  select(centroid, zone, urban, householdid,
+  select(centroidid, zone, urban, householdid,
          personid, surveystyear, surveystmonth,
          intwt0, gender, age, agem) %>%
   full_join(

--- a/src/mwi_survey_phia/script.R
+++ b/src/mwi_survey_phia/script.R
@@ -1,0 +1,392 @@
+
+#' ## Survey meta data
+
+iso3 <- "MWI"
+country <- "Malawi"
+survey_id  <- "MWI2016PHIA"
+survey_mid_calendar_quarter <- "CY2016Q1"
+fieldwork_start <- "2015-11-01"
+fieldwork_end <- "2016-08-01"
+
+
+#' ## Load area hierarchy
+areas <- read_sf("depends/mwi_areas.geojson")
+
+
+#' ## Load PHIA datasets
+sharepoint <- spud::sharepoint$new("https://imperiallondon.sharepoint.com/")
+
+phia_path <- "sites/HIVInferenceGroup-WP/Shared Documents/Data/household surveys/PHIA"
+
+paths <- list(geo = "datasets/MWI/datasets/MPHIA 2015-2016 PR Geospatial Data 20210917.zip",
+              survey = "datasets/MWI/datasets/MPHIA 2015-2016 Household Interview and Biomarker Datasets v2.0 (DTA).zip") %>%
+  lapply(function(x) file.path(phia_path, x)) %>%
+  lapply(URLencode)
+
+phia_files <- lapply(paths, sharepoint$download)
+
+geo <- rdhs::read_zipdata(phia_files$geo)
+
+hh <- rdhs::read_zipdata(phia_files$survey, "mphia2015hh.dta")
+bio <- rdhs::read_zipdata(phia_files$survey, "mphia2015adultbio.dta")
+ind <- rdhs::read_zipdata(phia_files$survey, "mphia2015adultind.dta")
+chbio <- rdhs::read_zipdata(phia_files$survey, "mphia2015childbio.dta")
+chind <- rdhs::read_zipdata(phia_files$survey, "mphia2015childind.dta")
+
+phia <- ind %>%
+  filter(indstatus == 1) %>%  # Respondent
+  select(varstrat, varunit, zone, urban, householdid,
+         personid, surveystyear, surveystmonth,
+         intwt0, gender, age, religion, ethnicgrp,
+         mcstatus, mcage, mcwho) %>%
+  full_join(
+    bio %>%
+    filter(bt_status == 1) %>%
+    select(personid, btwt0, hivstatusfinal, arvstatus, artselfreported,
+           vls, cd4count, recentlagvlarv),
+    by = "personid"
+  ) %>%
+  mutate(survey_id = survey_id,
+         cluster_id = paste(varstrat, varunit))
+
+
+#' Note: Religion and ethnic group were not asked for children. Strategy to
+#'       assign these based on `momid` if available, otherwise modal value
+#'       from the household. But the primary motivation for these variables
+#'       is for circumcision analysis, which is not asked for children.
+#' 
+
+chphia <- chind %>%
+  filter(indstatus == 1) %>%
+  select(varstrat, varunit, zone, urban, householdid,
+         personid, surveystyear, surveystmonth,
+         intwt0, gender, age, agem) %>%
+  full_join(
+    chbio %>%
+    filter(bt_status == 1) %>%
+    select(personid, btwt0, hivstatusfinal, arvstatus, pedartparentreported,
+           vls, cd4count, recentlagvlarv),
+    by = "personid"
+  ) %>%
+  mutate(survey_id = survey_id,
+         cluster_id = paste(varstrat, varunit))
+
+
+
+#' ## Survey regions
+#'
+#' This table identifies the smallest area in the area hierarchy which contains each
+#' region in the survey stratification, which is the smallest area to which a cluster
+#' can be assigned with certainty.
+
+hh$survey_region_id <- hh$zone # different in each survey dataset depending on survey stratification
+
+survey_region_id <- c("Northern" = 1,
+                      "Central East" = 2,
+                      "Central West" = 3,
+                      "Lilongwe City" = 4,
+                      "South East" = 5,
+                      "South West" = 6,
+                      "Blantyre City" = 7)
+
+#' Note: In MoH classifications, Mulanje is part of the South-East Zone.
+#'       In MPHIA, it is allocated to South-West Zone. Consequently,
+#'       the smallest area that contains the PHIA South-West Zone is the
+#'       level 1 Southern Region.
+
+survey_region_area_id <- c("Northern" = "MWI_2_1",
+                           "Central East" = "MWI_2_2",
+                           "Central West" = "MWI_2_3",
+                           "Lilongwe City" = "MWI_5_18",
+                           "South East" = "MWI_2_4",
+                           "South West" = "MWI_1_3",
+                           "Blantyre City" = "MWI_5_33")
+
+survey_regions <- tibble(survey_id = survey_id,
+                         survey_region_id = survey_region_id,
+                         survey_region_name = names(survey_region_id),
+                         survey_region_area_id = survey_region_area_id[names(survey_region_id)])
+  
+#' Add survey region boundary 
+
+survey_regions <- survey_regions %>%
+  left_join(
+    spread_areas(as.data.frame(areas)) %>%
+    left_join(select(areas, area_id), by = "area_id") %>%
+    st_as_sf() %>%
+    mutate(
+      survey_region_name = case_when(area_name3 == "Mulanje" ~ "South West",
+                                     area_name5 %in% c("Lilongwe City", "Blantyre City") ~ area_name5,
+                                     TRUE ~ sub("(East|West)ern", "\\1", area_name2))
+    ) %>%
+    group_by(survey_region_name) %>%
+    summarise(.groups = "drop"),
+    by = "survey_region_name"
+  ) %>%
+  st_as_sf()
+
+
+p_check_survey_regions <- ggplot(survey_regions) +
+  geom_sf(aes(fill = survey_region_name), color = "grey60", alpha = 0.6) +
+  geom_sf(data = areas %>% filter(area_level == 2), fill = NA, inherit.aes = FALSE) +
+  ggtitle("Survey regions and health zones (black lines)",
+          "Mulange is in South West in MPHIA but South East\nin MoH classification") +
+  naomi::th_map()
+
+dir.create("check")
+ggsave("check/compare_survey_regions.png", p_check_survey_regions, h=5, w=4)
+
+
+#' Inspect area_id assigments to confirm
+
+survey_regions %>%
+  left_join(
+    areas %>%
+    as.data.frame() %>%
+    select(area_id, area_name, area_level, area_level_label),
+    by = c("survey_region_area_id" = "area_id")
+  ) %>%
+  st_drop_geometry() %>%
+  select(survey_region_name, area_name, area_level_label)
+
+
+#' *** Should not require edits beyond this point ***
+
+#' ## Survey clusters dataset
+#'
+#' This data frame maps survey clusters to the highest level in the area hiearchy
+#' based on geomasked cluster centroids, additionally checking that the geolocated
+#' areas are contained in the survey region.
+
+survey_clusters <- hh %>%
+  transmute(survey_id = survey_id,
+            cluster_id = paste(varstrat, varunit),
+            cluster_id,
+            res_type = factor(urban, 1:2, c("urban", "rural")),
+            survey_region_id,
+            centroidid) %>%
+  distinct() %>%
+  left_join(geo, by = "centroidid") %>%
+  select(-centroidid) %>%
+  sf::st_as_sf(coords = c("longitude", "latitude"), remove = FALSE) %>%
+  sf::`st_crs<-`(4326)
+
+
+#' Snap clusters to areas
+#' 
+#' This is slow because it maps to the lowest level immediately
+#' It would be more efficient to do this recursively through
+#' the location hierarchy tree -- but not worth the effort right now.
+
+#' Create a list of all of the areas within each survey region
+#' (These are the candidate areas where a cluster could be located)
+
+survey_region_areas  <- survey_regions %>%
+  st_join(
+    st_point_on_surface(areas) %>%
+    filter(area_level == max(area_level)) %>%
+    select(area_id)
+  ) %>%
+  st_set_geometry(NULL) %>%
+  left_join(
+    areas %>% select(area_id, geometry),
+    by = "area_id"
+  ) %>%
+  select(survey_region_id, area_id, geometry_area = geometry)
+
+#' Calculate distance to each candidate area for each cluster
+
+survey_clusters <- survey_clusters %>%
+  left_join(survey_region_areas, by = "survey_region_id") %>%
+  mutate(
+    distance = unlist(Map(sf::st_distance, geometry, geometry_area))
+  )
+
+#' Keep the area with the smallest distance from cluster centroid.
+#' (Should be 0 for almost all)
+
+survey_clusters <- survey_clusters %>%
+  arrange(distance) %>%
+  group_by(survey_id, cluster_id) %>%
+  filter(row_number() == 1) %>%
+  ungroup() %>%
+  as.data.frame() %>%
+  transmute(survey_id,
+            cluster_id,
+            res_type,
+            survey_region_id,
+            longitude,
+            latitude,
+            geoloc_area_id = area_id,
+            geoloc_distance = distance)
+
+#' Review clusters outside admin area
+
+survey_clusters %>%
+  filter(geoloc_distance > 0) %>%
+  arrange(-geoloc_distance) %>%
+  left_join(survey_regions) 
+
+
+
+#' ## Survey individuals dataset
+
+religion_labels <- c(`1` = "Catholic",
+                     `2` = "CCAP",
+                     `3` = "Anglican",
+                     `4` = "Seventh Day Adventist",
+                     `5` = "Baptist",
+                     `6` = "Other Christian",
+                     `7` = "Muslim",
+                     `8` = "No religion",
+                     `96` = "Other",
+                     `-8` = "Don't know",
+                     `-9` = "Refused")
+
+ethnicgrp_labels <- c(`1` = "Nkhonde",
+                      `2` = "Tumbuka",
+                      `3` = "Tonga",
+                      `4` = "Yao",
+                      `5` = "Chewa",
+                      `6` = "Sena",
+                      `7` = "Lomwe",
+                      `8` = "Ngoni",
+                      `96` = "Other",
+                      `-8` = "Don’t know",
+                      `-9` = "Refused")
+
+mcstatus_lables <- c(`1` = "Yes",
+                     `2` = "No",
+                     `-8` = "Don't know",
+                     `-9` = "Refused")
+
+mcwho_labels = c(`1` = "Doctor, clinical officer, or nurse",
+                 `2` = "Traditional practitioner / circumciser",
+                 `3` = "Midwife",
+                 `96` = "Other",
+                 `-8` = "Don't know",
+                 `-9` = "Refused")
+
+mcwho_recode = c(`1` = "Healthcare worker",
+                 `2` = "Traditional practitioner",
+                 `3` = "Traditional practitioner",   ## TODO: UNSURE ON THIS
+                 `96` = "Traditional practitioner",
+                 `-8` = NA_character_,
+                 `-9` = NA_character_)
+
+
+#' Create individuals data
+
+survey_individuals <-
+  bind_rows(
+    phia %>%
+    transmute(
+      survey_id,
+      cluster_id,
+      individual_id = personid,
+      household = householdid,
+      line = personid,
+      interview_cmc = 12 * (surveystyear - 1900) + surveystmonth,
+      sex = factor(gender, 1:2, c("male", "female")),
+      age,
+      dob_cmc = NA,
+      religion = recode(religion, !!!religion_labels),
+      ethnicity = recode(ethnicgrp, !!!ethnicgrp_labels),
+      indweight = intwt0
+    ),
+    chphia %>%
+    transmute(
+      survey_id,
+      cluster_id,
+      individual_id = personid,
+      household = householdid,
+      line = personid,
+      interview_cmc = 12 * (surveystyear - 1900) + surveystmonth,
+      sex = factor(gender, 1:2, c("male", "female")),
+      age,
+      dob_cmc = interview_cmc - agem,
+      indweight = intwt0
+    )
+  ) %>%
+  mutate(age = as.integer(age),
+         indweight = indweight / mean(indweight, na.rm=TRUE)) 
+
+
+survey_biomarker <-
+  bind_rows(
+    phia %>%
+    filter(!is.na(hivstatusfinal)) %>%
+    transmute(
+      survey_id,
+      individual_id = personid,
+      hivweight = btwt0,
+      hivstatus = case_when(hivstatusfinal == 1 ~ 1,
+                            hivstatusfinal == 2 ~ 0),
+      arv = case_when(arvstatus == 1 ~ 1,
+                      arvstatus == 2 ~ 0),
+      artself = case_when(artselfreported == 1 ~ 1,
+                          artselfreported == 2 ~ 0),
+      vls = case_when(vls == 1 ~ 1,
+                      vls == 2 ~ 0),
+      cd4 = cd4count,
+      recent = case_when(recentlagvlarv == 1 ~ 1,
+                         recentlagvlarv == 2 ~ 0)
+    )
+   ,
+    chphia %>%
+    filter(!is.na(hivstatusfinal)) %>%
+    transmute(
+      survey_id,
+      individual_id = personid,
+      hivweight = btwt0,
+      hivstatus = case_when(hivstatusfinal == 1 ~ 1,
+                            hivstatusfinal == 2 ~ 0),
+      arv = case_when(arvstatus == 1 ~ 1,
+                      arvstatus == 2 ~ 0),
+      artself = case_when(pedartparentreported == 1 ~ 1,
+                          pedartparentreported == 2 ~ 0),
+      vls = case_when(vls == 1 ~ 1,
+                      vls == 2 ~ 0),
+      cd4 = cd4count,
+      recent = case_when(recentlagvlarv == 1 ~ 1,
+                         recentlagvlarv == 2 ~ 0)
+    )
+  ) %>%
+  mutate(hivweight = hivweight / mean(hivweight, na.rm = TRUE))
+
+
+survey_circumcision <- phia %>%
+  filter(gender == 1) %>%
+  transmute(
+    survey_id,
+    individual_id = personid,
+    circumcised = recode(mcstatus, `2` = 0L , `1` = 1L, .default = NA_integer_),
+    circ_age = mcage,
+    circ_where = NA_character_,
+    circ_who = recode(mcwho, !!!mcwho_recode)
+  )
+
+
+
+survey_meta <- survey_individuals %>%
+  group_by(survey_id) %>%
+  summarise(female_age_min = min(if_else(sex == "female", age, NA_integer_), na.rm=TRUE),
+            female_age_max = max(if_else(sex == "female", age, NA_integer_), na.rm=TRUE),
+            male_age_min = min(if_else(sex == "male", age, NA_integer_), na.rm=TRUE),
+            male_age_max = max(if_else(sex == "male", age, NA_integer_), na.rm=TRUE),
+            .groups = "drop") %>%
+  mutate(iso3 = substr(survey_id, 1, 3),
+         country = country,
+         survey_type = "PHIA",
+         survey_mid_calendar_quarter = recode(iso3, "MWI" = survey_mid_calendar_quarter),
+         fieldwork_start = fieldwork_start,
+         fieldwork_end   = fieldwork_end)
+
+#' ## Save survey datasets
+
+write_csv(survey_meta, paste0(tolower(survey_id), "_survey_meta.csv"), na = "")
+write_csv(survey_regions, paste0(tolower(survey_id), "_survey_regions.csv"), na = "")
+write_csv(survey_clusters, paste0(tolower(survey_id), "_survey_clusters.csv"), na = "")
+write_csv(survey_individuals, paste0(tolower(survey_id), "_survey_individuals.csv"), na = "")
+write_csv(survey_biomarker, paste0(tolower(survey_id), "_survey_biomarker.csv"), na = "")
+write_csv(survey_circumcision, paste0(tolower(survey_id), "_survey_circumcision.csv"), na = "")

--- a/src/mwi_survey_phia/script.R
+++ b/src/mwi_survey_phia/script.R
@@ -35,7 +35,7 @@ chind <- rdhs::read_zipdata(phia_files$survey, "mphia2015childind.dta")
 
 phia <- ind %>%
   filter(indstatus == 1) %>%  # Respondent
-  select(varstrat, varunit, zone, urban, householdid,
+  select(centroidid, zone, urban, householdid,
          personid, surveystyear, surveystmonth,
          intwt0, gender, age, religion, ethnicgrp,
          mcstatus, mcage, mcwho) %>%
@@ -47,7 +47,7 @@ phia <- ind %>%
     by = "personid"
   ) %>%
   mutate(survey_id = survey_id,
-         cluster_id = paste(varstrat, varunit))
+         cluster_id = centroidid)
 
 
 #' Note: Religion and ethnic group were not asked for children. Strategy to
@@ -58,7 +58,7 @@ phia <- ind %>%
 
 chphia <- chind %>%
   filter(indstatus == 1) %>%
-  select(varstrat, varunit, zone, urban, householdid,
+  select(centroid, zone, urban, householdid,
          personid, surveystyear, surveystmonth,
          intwt0, gender, age, agem) %>%
   full_join(
@@ -69,7 +69,7 @@ chphia <- chind %>%
     by = "personid"
   ) %>%
   mutate(survey_id = survey_id,
-         cluster_id = paste(varstrat, varunit))
+         cluster_id = centroidid)
 
 
 
@@ -160,14 +160,12 @@ survey_regions %>%
 
 survey_clusters <- hh %>%
   transmute(survey_id = survey_id,
-            cluster_id = paste(varstrat, varunit),
+            cluster_id = centroidid,
             cluster_id,
             res_type = factor(urban, 1:2, c("urban", "rural")),
-            survey_region_id,
-            centroidid) %>%
+            survey_region_id) %>%
   distinct() %>%
-  left_join(geo, by = "centroidid") %>%
-  select(-centroidid) %>%
+  left_join(geo, by = c("cluster_id" = "centroidid")) %>%
   sf::st_as_sf(coords = c("longitude", "latitude"), remove = FALSE) %>%
   sf::`st_crs<-`(4326)
 

--- a/src/nam_survey_phia/orderly.yml
+++ b/src/nam_survey_phia/orderly.yml
@@ -2,7 +2,7 @@ script: script.R
 
 artefacts:
   - data:
-      description: LePHIA 2016-17 survey microdata
+      description: NAMPHIA 2017 survey microdata
       filenames:
         - nam2017phia_survey_meta.csv
         - nam2017phia_survey_regions.csv

--- a/src/nam_survey_phia/orderly.yml
+++ b/src/nam_survey_phia/orderly.yml
@@ -1,0 +1,29 @@
+script: script.R
+
+artefacts:
+  - data:
+      description: LePHIA 2016-17 survey microdata
+      filenames:
+        - nam2017phia_survey_meta.csv
+        - nam2017phia_survey_regions.csv
+        - nam2017phia_survey_clusters.csv
+        - nam2017phia_survey_individuals.csv
+        - nam2017phia_survey_biomarker.csv
+        - nam2017phia_survey_circumcision.csv
+
+packages:
+  - dplyr
+  - ggplot2
+  - haven
+  - naomi
+  - spud
+  - rdhs
+  - readr
+  - sf
+
+depends:
+  nam_data_areas:
+    id: latest
+    use:
+      depends/nam_areas.geojson: nam_areas.geojson
+  

--- a/src/nam_survey_phia/script.R
+++ b/src/nam_survey_phia/script.R
@@ -1,0 +1,366 @@
+
+#' ## Survey meta data
+
+iso3 <- "NAM"
+country <- "Namibia"
+survey_id  <- "NAM2017PHIA"
+survey_mid_calendar_quarter <- "CY2017Q3"
+fieldwork_start <- NA
+fieldwork_end <- NA
+
+
+#' ## Load area hierarchy
+areas <- read_sf("depends/nam_areas.geojson")
+
+
+#' ## Load PHIA datasets
+sharepoint <- spud::sharepoint$new("https://imperiallondon.sharepoint.com/")
+
+phia_path <- "sites/HIVInferenceGroup-WP/Shared Documents/Data/household surveys/PHIA/datasets/NAM/datasets"
+
+paths <- list(geo = "NAMPHIA 2017 PR Geospatial Data 20210603.zip",
+              hh = "102 NAMPHIA 2017 Household Dataset (DTA).zip",
+              ind = "202_NAMPHIA 2017 Adult Interview Dataset (DTA).zip",
+              bio = "302_NAMPHIA 2017 Adult Biomarker Dataset (DTA).zip",
+              chind = "205 NAMPHIA 2017 Child Interview Dataset (DTA).zip",
+              chbio = "305 NAMPHIA 2017 Child Biomarker Dataset (DTA).zip") %>%
+  lapply(function(x) file.path(phia_path, x)) %>%
+  lapply(URLencode)
+
+phia_files <- lapply(paths, sharepoint$download)
+
+geo <- rdhs::read_zipdata(phia_files$geo)
+
+hh <- rdhs::read_zipdata(phia_files$hh)
+bio <- rdhs::read_zipdata(phia_files$bio)
+ind <- rdhs::read_zipdata(phia_files$ind)
+chbio <- rdhs::read_zipdata(phia_files$chbio)
+chind <- rdhs::read_zipdata(phia_files$chind)
+
+
+#' Note: Religion and ethnicity  not asked.
+#' 
+
+phia <- ind %>%
+  filter(indstatus == 1) %>%  # Respondent
+  select(varstrat, varunit, region, urban, householdid,
+         personid, surveystyear, surveystmonth,
+         intwt0, gender, age,
+         mcstatus, mcage, mcwho) %>%
+  full_join(
+    bio %>%
+    filter(bt_status == 1) %>%
+    select(personid, btwt0, hivstatusfinal, arvstatus, artselfreported,
+           vls, cd4count, recentlagvlarv),
+    by = "personid"
+  ) %>%
+  mutate(survey_id = survey_id,
+         cluster_id = paste(varstrat, varunit))
+
+chphia <- chind %>%
+  filter(indstatus == 1) %>%
+  select(varstrat, varunit, region, urban, householdid,
+         personid, surveystyear, surveystmonth,
+         intwt0, gender, age, agem) %>%
+  full_join(
+    chbio %>%
+    filter(bt_status == 1) %>%
+    select(personid, btwt0, hivstatusfinal, arvstatus, pedartparentreported,
+           vls, cd4count, recentlagvlarv),
+    by = "personid"
+  ) %>%
+  mutate(survey_id = survey_id,
+         cluster_id = paste(varstrat, varunit))
+
+
+
+#' ## Survey regions
+#'
+#' This table identifies the smallest area in the area hierarchy which contains each
+#' region in the survey stratification, which is the smallest area to which a cluster
+#' can be assigned with certainty.
+
+hh$survey_region_id <- hh$region # different in each survey dataset depending on survey stratification
+
+survey_region_id <- c("Erongo" = 1,
+                      "Hardap" = 2,
+                      "Karas" = 3,
+                      "Kavango East" = 4,
+                      "Kavango West" = 5,
+                      "Khomas" = 6,
+                      "Kunene" = 7,
+                      "Ohangwena" = 8,
+                      "Omaheke" = 9,
+                      "Omusati" = 10,
+                      "Oshana" = 11,
+                      "Oshikoto" = 12,
+                      "Otjozondjupa" = 13,
+                      "Zambezi" = 14)
+
+areas %>%
+  st_drop_geometry() %>%
+  filter(area_level == 1) %>%
+  select(area_id, area_name) %>%
+  left_join(
+    data.frame(survey_region_name = names(survey_region_id)) %>%
+    mutate(area_name = survey_region_name %>%
+             recode("Karas" = "!Karas"))
+  ) %>%
+  mutate(str = paste0("\"", survey_region_name, "\" = \"", area_id, "\",")) %>%
+  select(str)
+
+survey_region_area_id <- c("Karas" = "NAM_1_01",
+                           "Erongo" = "NAM_1_02",
+                           "Hardap" = "NAM_1_03",
+                           "Kavango East" = "NAM_1_04",
+                           "Kavango West" = "NAM_1_05",
+                           "Khomas" = "NAM_1_06",
+                           "Kunene" = "NAM_1_07",
+                           "Ohangwena" = "NAM_1_08",
+                           "Omaheke" = "NAM_1_09",
+                           "Omusati" = "NAM_1_10",
+                           "Oshana" = "NAM_1_11",
+                           "Oshikoto" = "NAM_1_12",
+                           "Otjozondjupa" = "NAM_1_13",
+                           "Zambezi" = "NAM_1_14")
+
+survey_regions <- tibble(survey_id = survey_id,
+                         survey_region_id = survey_region_id,
+                         survey_region_name = names(survey_region_id),
+                         survey_region_area_id = survey_region_area_id[names(survey_region_id)])
+
+
+#' Add survey region boundary
+
+survey_regions <- survey_regions %>%
+  left_join(
+    areas %>% select(survey_region_area_id = area_id)
+  ) %>%
+  st_as_sf() %>%
+  st_make_valid()
+
+#' Inspect area_id assigments to confirm
+
+survey_regions %>%
+  left_join(
+    areas %>%
+    as.data.frame() %>%
+    select(area_id, area_name, area_level, area_level_label),
+    by = c("survey_region_area_id" = "area_id")
+  )
+
+
+#' *** Should not require edits beyond this point ***
+
+#' ## Survey clusters dataset
+#'
+#' This data frame maps survey clusters to the highest level in the area hiearchy
+#' based on geomasked cluster centroids, additionally checking that the geolocated
+#' areas are contained in the survey region.
+
+survey_clusters <- hh %>%
+  transmute(survey_id = survey_id,
+            cluster_id = paste(varstrat, varunit),
+            cluster_id,
+            res_type = factor(urban, 1:2, c("urban", "rural")),
+            survey_region_id,
+            centroidid) %>%
+  distinct() %>%
+  left_join(geo, by = "centroidid") %>%
+  select(-centroidid) %>%
+  sf::st_as_sf(coords = c("longitude", "latitude"), remove = FALSE) %>%
+  sf::`st_crs<-`(4326)
+
+
+#' Snap clusters to areas
+#' 
+#' This is slow because it maps to the lowest level immediately
+#' It would be more efficient to do this recursively through
+#' the location hierarchy tree -- but not worth the effort right now.
+
+#' Create a list of all of the areas within each survey region
+#' (These are the candidate areas where a cluster could be located)
+
+survey_region_areas  <- survey_regions %>%
+  st_join(
+    st_point_on_surface(areas) %>%
+    filter(area_level == max(area_level)) %>%
+    select(area_id)
+  ) %>%
+  st_set_geometry(NULL) %>%
+  left_join(
+    areas %>% select(area_id, geometry),
+    by = "area_id"
+  ) %>%
+  select(survey_region_id, area_id, geometry_area = geometry)
+
+#' Calculate distance to each candidate area for each cluster
+
+survey_clusters <- survey_clusters %>%
+  left_join(survey_region_areas, by = "survey_region_id") %>%
+  mutate(
+    distance = unlist(Map(sf::st_distance, geometry, geometry_area))
+  )
+
+#' Keep the area with the smallest distance from cluster centroid.
+#' (Should be 0 for almost all)
+
+survey_clusters <- survey_clusters %>%
+  arrange(distance) %>%
+  group_by(survey_id, cluster_id) %>%
+  filter(row_number() == 1) %>%
+  ungroup() %>%
+  as.data.frame() %>%
+  transmute(survey_id,
+            cluster_id,
+            res_type,
+            survey_region_id,
+            longitude,
+            latitude,
+            geoloc_area_id = area_id,
+            geoloc_distance = distance)
+
+#' Review clusters outside admin area
+
+survey_clusters %>%
+  filter(geoloc_distance > 0) %>%
+  arrange(-geoloc_distance) %>%
+  left_join(survey_regions) 
+
+#' ## Survey individuals dataset
+
+mcstatus_lables <- c(`1` = "Yes",
+                     `2` = "No",
+                     `-8` = "Don't know",
+                     `-9` = "Refused")
+
+mcwho_labels = c(`1` = "Doctor, clinical officer, or nurse",
+                 `2` = "Traditional practitioner / circumciser",
+                 `3` = "Midwife",
+                 `4` = "Family/Friend",
+                 `96` = "Other",
+                 `-8` = "Don't know",
+                 `-9` = "Refused")
+
+mcwho_recode = c(`1` = "Healthcare worker",
+                 `2` = "Traditional practitioner",
+                 `3` = "Traditional practitioner",   ## TODO: UNSURE ON THIS
+                 `4` = "Traditional practitioner",   ## TODO: UNSURE ON THIS
+                 `96` = "Traditional practitioner",
+                 `-8` = NA_character_,
+                 `-9` = NA_character_)
+
+
+#' Create individuals data
+
+survey_individuals <-
+  bind_rows(
+    phia %>%
+    transmute(
+      survey_id,
+      cluster_id,
+      individual_id = personid,
+      household = householdid,
+      line = personid,
+      interview_cmc = 12 * (surveystyear - 1900) + surveystmonth,
+      sex = factor(gender, 1:2, c("male", "female")),
+      age,
+      dob_cmc = NA,
+      indweight = intwt0
+    ),
+    chphia %>%
+    transmute(
+      survey_id,
+      cluster_id,
+      individual_id = personid,
+      household = householdid,
+      line = personid,
+      interview_cmc = 12 * (surveystyear - 1900) + surveystmonth,
+      sex = factor(gender, 1:2, c("male", "female")),
+      age,
+      dob_cmc = interview_cmc - agem,
+      indweight = intwt0
+    )
+  ) %>%
+  mutate(age = as.integer(age),
+         indweight = indweight / mean(indweight, na.rm=TRUE)) 
+
+
+survey_biomarker <-
+  bind_rows(
+    phia %>%
+    filter(!is.na(hivstatusfinal)) %>%
+    transmute(
+      survey_id,
+      individual_id = personid,
+      hivweight = btwt0,
+      hivstatus = case_when(hivstatusfinal == 1 ~ 1,
+                            hivstatusfinal == 2 ~ 0),
+      arv = case_when(arvstatus == 1 ~ 1,
+                      arvstatus == 2 ~ 0),
+      artself = case_when(artselfreported == 1 ~ 1,
+                          artselfreported == 2 ~ 0),
+      vls = case_when(vls == 1 ~ 1,
+                      vls == 2 ~ 0),
+      cd4 = cd4count,
+      recent = case_when(recentlagvlarv == 1 ~ 1,
+                         recentlagvlarv == 2 ~ 0)
+    )
+   ,
+    chphia %>%
+    filter(!is.na(hivstatusfinal)) %>%
+    transmute(
+      survey_id,
+      individual_id = personid,
+      hivweight = btwt0,
+      hivstatus = case_when(hivstatusfinal == 1 ~ 1,
+                            hivstatusfinal == 2 ~ 0),
+      arv = case_when(arvstatus == 1 ~ 1,
+                      arvstatus == 2 ~ 0),
+      artself = case_when(pedartparentreported == 1 ~ 1,
+                          pedartparentreported == 2 ~ 0),
+      vls = case_when(vls == 1 ~ 1,
+                      vls == 2 ~ 0),
+      cd4 = cd4count,
+      recent = case_when(recentlagvlarv == 1 ~ 1,
+                         recentlagvlarv == 2 ~ 0)
+    )
+  ) %>%
+  mutate(hivweight = hivweight / mean(hivweight, na.rm = TRUE))
+
+
+survey_circumcision <- phia %>%
+  filter(gender == 1) %>%
+  transmute(
+    survey_id,
+    individual_id = personid,
+    circumcised = recode(mcstatus, `2` = 0L , `1` = 1L, .default = NA_integer_),
+    circ_age = mcage,
+    circ_where = NA_character_,
+    circ_who = recode(mcwho, !!!mcwho_recode)
+  )
+
+
+
+survey_meta <- survey_individuals %>%
+  group_by(survey_id) %>%
+  summarise(female_age_min = min(if_else(sex == "female", age, NA_integer_), na.rm=TRUE),
+            female_age_max = max(if_else(sex == "female", age, NA_integer_), na.rm=TRUE),
+            male_age_min = min(if_else(sex == "male", age, NA_integer_), na.rm=TRUE),
+            male_age_max = max(if_else(sex == "male", age, NA_integer_), na.rm=TRUE),
+            .groups = "drop") %>%
+  mutate(iso3 = substr(survey_id, 1, 3),
+         country = country,
+         survey_type = "PHIA",
+         survey_mid_calendar_quarter = recode(iso3, "MWI" = survey_mid_calendar_quarter),
+         fieldwork_start = fieldwork_start,
+         fieldwork_end   = fieldwork_end)
+
+#' ## Save survey datasets
+
+write_csv(survey_meta, paste0(tolower(survey_id), "_survey_meta.csv"), na = "")
+write_csv(survey_regions, paste0(tolower(survey_id), "_survey_regions.csv"), na = "")
+write_csv(survey_clusters, paste0(tolower(survey_id), "_survey_clusters.csv"), na = "")
+write_csv(survey_individuals, paste0(tolower(survey_id), "_survey_individuals.csv"), na = "")
+write_csv(survey_biomarker, paste0(tolower(survey_id), "_survey_biomarker.csv"), na = "")
+write_csv(survey_circumcision, paste0(tolower(survey_id), "_survey_circumcision.csv"), na = "")

--- a/src/nam_survey_phia/script.R
+++ b/src/nam_survey_phia/script.R
@@ -43,7 +43,7 @@ chind <- rdhs::read_zipdata(phia_files$chind)
 
 phia <- ind %>%
   filter(indstatus == 1) %>%  # Respondent
-  select(varstrat, varunit, region, urban, householdid,
+  select(centroidid, region, urban, householdid,
          personid, surveystyear, surveystmonth,
          intwt0, gender, age,
          mcstatus, mcage, mcwho) %>%
@@ -55,11 +55,11 @@ phia <- ind %>%
     by = "personid"
   ) %>%
   mutate(survey_id = survey_id,
-         cluster_id = paste(varstrat, varunit))
+         cluster_id = centroidid)
 
 chphia <- chind %>%
   filter(indstatus == 1) %>%
-  select(varstrat, varunit, region, urban, householdid,
+  select(centroidid, region, urban, householdid,
          personid, surveystyear, surveystmonth,
          intwt0, gender, age, agem) %>%
   full_join(
@@ -70,7 +70,7 @@ chphia <- chind %>%
     by = "personid"
   ) %>%
   mutate(survey_id = survey_id,
-         cluster_id = paste(varstrat, varunit))
+         cluster_id = centroidid)
 
 
 
@@ -160,14 +160,12 @@ survey_regions %>%
 
 survey_clusters <- hh %>%
   transmute(survey_id = survey_id,
-            cluster_id = paste(varstrat, varunit),
+            cluster_id = centroidid,
             cluster_id,
             res_type = factor(urban, 1:2, c("urban", "rural")),
-            survey_region_id,
-            centroidid) %>%
+            survey_region_id) %>%
   distinct() %>%
-  left_join(geo, by = "centroidid") %>%
-  select(-centroidid) %>%
+  left_join(geo, by = c("cluster_id" = "centroidid")) %>%
   sf::st_as_sf(coords = c("longitude", "latitude"), remove = FALSE) %>%
   sf::`st_crs<-`(4326)
 

--- a/src/rwa_survey/rwa_survey.R
+++ b/src/rwa_survey/rwa_survey.R
@@ -1,5 +1,3 @@
-orderly::orderly_pull_archive("rwa_data_areas")
-
 #' ISO3 country code
 iso3 <- "RWA"
 
@@ -14,8 +12,7 @@ surveys <- create_surveys_dhs(iso3, survey_characteristics = NULL) %>%
 
 #' This is the contents of naomi.utils::create_survey_meta_dhs. Unpacked to get around 2 reports for 2005 DHS which fails the duplicated check
 publications <- rdhs::dhs_publications(surveyIds = surveys$SurveyId)
-final_rep <- dplyr::filter(publications, PublicationTitle == 
-                             "Final Report")
+final_rep <- dplyr::filter(publications, PublicationTitle == "Final Report")
 final_rep <- dplyr::select(final_rep, SurveyId, report_url = PublicationURL) %>%
   dplyr::group_by(SurveyId) %>%
   dplyr::filter(row_number() == 1)
@@ -87,6 +84,7 @@ ggplot() +
         axis.ticks = element_blank(),
         panel.grid = element_blank())
 
+dev.off()
 
 #' The three current Kigali City districts overlap both the Kigali City and Kigali
 #' Rural regions in the 2000 DHS.

--- a/src/rwa_survey_phia/orderly.yml
+++ b/src/rwa_survey_phia/orderly.yml
@@ -1,0 +1,33 @@
+script: script.R
+
+artefacts:
+  - data:
+      description: RPHIA 2018-2019 survey microdata
+      filenames:
+        - rwa2018phia_survey_meta.csv
+        - rwa2018phia_survey_regions.csv
+        - rwa2018phia_survey_clusters.csv
+        - rwa2018phia_survey_individuals.csv
+        - rwa2018phia_survey_biomarker.csv
+        - rwa2018phia_survey_circumcision.csv
+  - staticgraph:
+       description: RPHIA survey regions vs. area hierarchy
+       filenames:
+         - check/rphia-survey-region-boundaries.png
+
+packages:
+  - dplyr
+  - ggplot2
+  - haven
+  - naomi
+  - spud
+  - rdhs
+  - readr
+  - sf
+
+depends:
+  rwa_data_areas:
+    id: latest
+    use:
+      depends/rwa_areas.geojson: rwa_areas.geojson
+  

--- a/src/rwa_survey_phia/script.R
+++ b/src/rwa_survey_phia/script.R
@@ -1,0 +1,337 @@
+
+iso3 <- "RWA"
+country <- "Rwanda"
+survey_id  <- "RWA2018PHIA"
+survey_mid_calendar_quarter <- "CY2018Q4"
+
+
+#' ## Load area hierarchy
+areas <- read_sf("depends/rwa_areas.geojson")
+
+
+#' ## Load PHIA datasets
+sharepoint <- spud::sharepoint$new("https://imperiallondon.sharepoint.com/")
+
+phia_path <- "sites/HIVInferenceGroup-WP/Shared Documents/Data/household surveys/PHIA"
+
+paths <- list(geo = "datasets/RWA/datasets/RPHIA 2018-2019 PR Geospatial Data 20210722.zip",
+               hh = "datasets/RWA/datasets/102_RPHIA 2018-2019 Household Dataset (DTA).zip",
+              ind = "datasets/RWA/datasets/202_202 RPHIA 2018-2019 Adult Interview Dataset (DTA).zip",
+              bio = "datasets/RWA/datasets/302 RPHIA 2018-2019 Adult Biomarker Dataset (DTA).zip",
+              chind = "datasets/RWA/datasets/205_RPHIA 2018-2019 Child Interview Dataset (DTA).zip",
+              chbio = "datasets/RWA/datasets/305 RPHIA 2018-2019 Child Biomarker Dataset (DTA).zip") %>%
+  lapply(function(x) file.path(phia_path, x)) %>%
+  lapply(URLencode)
+
+
+phia_files <- lapply(paths, sharepoint$download)
+
+
+geo <- rdhs::read_zipdata(phia_files$geo)
+
+hh <- rdhs::read_zipdata(phia_files$hh)
+bio <- rdhs::read_zipdata(phia_files$bio)
+ind <- rdhs::read_zipdata(phia_files$ind)
+chbio <- rdhs::read_zipdata(phia_files$chbio)
+chind <- rdhs::read_zipdata(phia_files$chind)
+
+#' Note: Religion and ethnic group were not asked. CD4 count as not done
+#' 
+phia <- ind %>%
+  filter(indstatus == 1) %>%  # Respondent
+  select(varstrat, varunit, province, urban, householdid,
+         personid, surveystyear, surveystmonth,
+         intwt0, gender, age,
+         mcstatus, mcage, mcwho) %>%
+  full_join(
+    bio %>%
+    filter(bt_status == 1) %>%
+    select(personid, btwt0, hivstatusfinal, arvstatus, artselfreported,
+           vls, recentlagvlarv),
+    by = "personid"
+  ) %>%
+  mutate(survey_id = survey_id,
+         cluster_id = paste(varstrat, varunit))
+
+
+chphia <- chind %>%
+  filter(indstatus == 1) %>%
+  select(varstrat, varunit, province, urban, householdid,
+         personid, surveystyear, surveystmonth,
+         intwt0, gender, age, agem) %>%
+  full_join(
+    chbio %>%
+    filter(bt_status == 1) %>%
+    select(personid, btwt0, hivstatusfinal, arvstatus,
+           vls, recentlagvlarv),
+    by = "personid"
+  ) %>%
+  mutate(survey_id = survey_id,
+         cluster_id = paste(varstrat, varunit))
+
+
+
+#' ## Survey regions
+#'
+#' This table identifies the smallest area in the area hierarchy which contains each
+#' region in the survey stratification, which is the smallest area to which a cluster
+#' can be assigned with certainty.
+
+hh$survey_region_id <- hh$province # different in each survey dataset depending on survey stratification
+
+survey_region_id <- c("City of Kigali" = 1,
+                      "South" = 2,
+                      "West" = 3,
+                      "North" = 4,
+                      "East" = 5)
+
+areas %>% filter(area_level == 1) %>% select(area_id, area_name)
+
+survey_region_area_id <- c("City of Kigali" = "RWA_1_1",
+                           "South" = "RWA_1_2",
+                           "West" = "RWA_1_3",
+                           "North" = "RWA_1_4",
+                           "East" = "RWA_1_5")
+
+survey_regions <- tibble(survey_id = survey_id,
+                         survey_region_id = survey_region_id,
+                         survey_region_name = names(survey_region_id),
+                         survey_region_area_id = survey_region_area_id[names(survey_region_id)])
+
+
+#' Add survey region boundary
+
+survey_regions <- survey_regions %>%
+  left_join(
+    areas %>% select(survey_region_area_id = area_id)
+  ) %>%
+  st_as_sf()
+
+p_survey_regions <- ggplot(survey_regions) +
+  geom_sf(aes(fill = survey_region_name), color = "grey60", alpha = 0.6) +
+  geom_sf(data = areas %>% filter(area_level == 1), fill = NA, inherit.aes = FALSE)
+
+dir.create("check")
+ggsave("check/rphia-survey-region-boundaries.png", p_survey_regions, h = 7, w = 7)
+
+#' Inspect area_id assigments to confirm
+
+survey_regions %>%
+  left_join(
+    areas %>%
+    as.data.frame() %>%
+    select(area_id, area_name, area_level, area_level_label),
+    by = c("survey_region_area_id" = "area_id")
+  )
+
+
+#' *** Should not require edits beyond this point ***
+
+#' ## Survey clusters dataset
+#'
+#' This data frame maps survey clusters to the highest level in the area hiearchy
+#' based on geomasked cluster centroids, additionally checking that the geolocated
+#' areas are contained in the survey region.
+
+survey_clusters <- hh %>%
+  transmute(survey_id = survey_id,
+            cluster_id = paste(varstrat, varunit),
+            cluster_id,
+            res_type = factor(urban, 1:2, c("urban", "rural")),
+            survey_region_id,
+            centroidid) %>%
+  distinct() %>%
+  left_join(geo, by = "centroidid") %>%
+  select(-centroidid) %>%
+  sf::st_as_sf(coords = c("longitude", "latitude"), remove = FALSE) %>%
+  sf::`st_crs<-`(4326)
+
+
+#' Snap clusters to areas
+#' 
+#' This is slow because it maps to the lowest level immediately
+#' It would be more efficient to do this recursively through
+#' the location hierarchy tree -- but not worth the effort right now.
+
+#' Create a list of all of the areas within each survey region
+#' (These are the candidate areas where a cluster could be located)
+
+survey_region_areas  <- survey_regions %>%
+  st_join(
+    st_point_on_surface(areas) %>%
+    filter(area_level == max(area_level)) %>%
+    select(area_id)
+  ) %>%
+  st_set_geometry(NULL) %>%
+  left_join(
+    areas %>% select(area_id, geometry),
+    by = "area_id"
+  ) %>%
+  select(survey_region_id, area_id, geometry_area = geometry)
+
+#' Calculate distance to each candidate area for each cluster
+
+survey_clusters <- survey_clusters %>%
+  left_join(survey_region_areas, by = "survey_region_id") %>%
+  mutate(
+    distance = unlist(Map(sf::st_distance, geometry, geometry_area))
+  )
+
+#' Keep the area with the smallest distance from cluster centroid.
+#' (Should be 0 for almost all)
+
+survey_clusters <- survey_clusters %>%
+  arrange(distance) %>%
+  group_by(survey_id, cluster_id) %>%
+  filter(row_number() == 1) %>%
+  ungroup() %>%
+  as.data.frame() %>%
+  transmute(survey_id,
+            cluster_id,
+            res_type,
+            survey_region_id,
+            longitude,
+            latitude,
+            geoloc_area_id = area_id,
+            geoloc_distance = distance)
+
+#' Review clusters outside admin area
+
+survey_clusters %>%
+  filter(geoloc_distance > 0) %>%
+  arrange(-geoloc_distance) %>%
+  left_join(survey_regions) 
+
+
+
+#' ## Survey individuals dataset
+
+mcstatus_lables <- c(`1` = "Yes",
+                     `2` = "No",
+                     `-8` = "Don't know",
+                     `-9` = "Refused")
+
+mcwho_labels = c(`1` = "Doctor, clinical officer, or nurse",
+                 `2` = "Traditional practitioner / circumciser",
+                 `3` = "Midwife",
+                 `96` = "Other",
+                 `-8` = "Don't know",
+                 `-9` = "Refused")
+
+mcwho_recode = c(`1` = "Healthcare worker",
+                 `2` = "Traditional practitioner",
+                 `3` = "Traditional practitioner",   ## TODO: UNSURE ON THIS
+                 `96` = "Traditional practitioner",
+                 `-8` = NA_character_,
+                 `-9` = NA_character_)
+
+
+#' Create individuals data
+
+survey_individuals <-
+  bind_rows(
+    phia %>%
+    transmute(
+      survey_id,
+      cluster_id,
+      individual_id = personid,
+      household = householdid,
+      line = personid,
+      interview_cmc = 12 * (surveystyear - 1900) + surveystmonth,
+      sex = factor(gender, 1:2, c("male", "female")),
+      age,
+      dob_cmc = NA,
+      indweight = intwt0
+    ),
+    chphia %>%
+    transmute(
+      survey_id,
+      cluster_id,
+      individual_id = personid,
+      household = householdid,
+      line = personid,
+      interview_cmc = 12 * (surveystyear - 1900) + surveystmonth,
+      sex = factor(gender, 1:2, c("male", "female")),
+      age,
+      dob_cmc = interview_cmc - agem,
+      indweight = intwt0
+    )
+  ) %>%
+  mutate(age = as.integer(age),
+         indweight = indweight / mean(indweight, na.rm=TRUE)) 
+
+
+survey_biomarker <-
+  bind_rows(
+    phia %>%
+    filter(!is.na(hivstatusfinal)) %>%
+    transmute(
+      survey_id,
+      individual_id = personid,
+      hivweight = btwt0,
+      hivstatus = case_when(hivstatusfinal == 1 ~ 1,
+                            hivstatusfinal == 2 ~ 0),
+      arv = case_when(arvstatus == 1 ~ 1,
+                      arvstatus == 2 ~ 0),
+      artself = case_when(artselfreported == 1 ~ 1,
+                          artselfreported == 2 ~ 0),
+      vls = case_when(vls == 1 ~ 1,
+                      vls == 2 ~ 0),
+      recent = case_when(recentlagvlarv == 1 ~ 1,
+                         recentlagvlarv == 2 ~ 0)
+    )
+   ,
+    chphia %>%
+    filter(!is.na(hivstatusfinal)) %>%
+    transmute(
+      survey_id,
+      individual_id = personid,
+      hivweight = btwt0,
+      hivstatus = case_when(hivstatusfinal == 1 ~ 1,
+                            hivstatusfinal == 2 ~ 0),
+      arv = case_when(arvstatus == 1 ~ 1,
+                      arvstatus == 2 ~ 0),
+      vls = case_when(vls == 1 ~ 1,
+                      vls == 2 ~ 0),
+      recent = case_when(recentlagvlarv == 1 ~ 1,
+                         recentlagvlarv == 2 ~ 0)
+    )
+  ) %>%
+  mutate(hivweight = hivweight / mean(hivweight, na.rm = TRUE))
+
+
+survey_circumcision <- phia %>%
+  filter(gender == 1) %>%
+  transmute(
+    survey_id,
+    individual_id = personid,
+    circumcised = recode(mcstatus, `2` = 0L , `1` = 1L, .default = NA_integer_),
+    circ_age = mcage,
+    circ_where = NA_character_,
+    circ_who = recode(mcwho, !!!mcwho_recode)
+  )
+
+
+
+survey_meta <- survey_individuals %>%
+  group_by(survey_id) %>%
+  summarise(female_age_min = min(if_else(sex == "female", age, NA_integer_), na.rm=TRUE),
+            female_age_max = max(if_else(sex == "female", age, NA_integer_), na.rm=TRUE),
+            male_age_min = min(if_else(sex == "male", age, NA_integer_), na.rm=TRUE),
+            male_age_max = max(if_else(sex == "male", age, NA_integer_), na.rm=TRUE),
+            .groups = "drop") %>%
+  mutate(iso3 = substr(survey_id, 1, 3),
+         country = country,
+         survey_type = "PHIA",
+         survey_mid_calendar_quarter = survey_mid_calendar_quarter,
+         fieldwork_start = NA,
+         fieldwork_end   = NA)
+
+#' ## Save survey datasets
+
+write_csv(survey_meta, paste0(tolower(survey_id), "_survey_meta.csv"), na = "")
+write_csv(survey_regions, paste0(tolower(survey_id), "_survey_regions.csv"), na = "")
+write_csv(survey_clusters, paste0(tolower(survey_id), "_survey_clusters.csv"), na = "")
+write_csv(survey_individuals, paste0(tolower(survey_id), "_survey_individuals.csv"), na = "")
+write_csv(survey_biomarker, paste0(tolower(survey_id), "_survey_biomarker.csv"), na = "")
+write_csv(survey_circumcision, paste0(tolower(survey_id), "_survey_circumcision.csv"), na = "")

--- a/src/rwa_survey_phia/script.R
+++ b/src/rwa_survey_phia/script.R
@@ -39,7 +39,7 @@ chind <- rdhs::read_zipdata(phia_files$chind)
 #' 
 phia <- ind %>%
   filter(indstatus == 1) %>%  # Respondent
-  select(varstrat, varunit, province, urban, householdid,
+  select(centroidid, province, urban, householdid,
          personid, surveystyear, surveystmonth,
          intwt0, gender, age,
          mcstatus, mcage, mcwho) %>%
@@ -51,12 +51,12 @@ phia <- ind %>%
     by = "personid"
   ) %>%
   mutate(survey_id = survey_id,
-         cluster_id = paste(varstrat, varunit))
+         cluster_id = centroidid)
 
 
 chphia <- chind %>%
   filter(indstatus == 1) %>%
-  select(varstrat, varunit, province, urban, householdid,
+  select(centroidid, province, urban, householdid,
          personid, surveystyear, surveystmonth,
          intwt0, gender, age, agem) %>%
   full_join(
@@ -67,7 +67,7 @@ chphia <- chind %>%
     by = "personid"
   ) %>%
   mutate(survey_id = survey_id,
-         cluster_id = paste(varstrat, varunit))
+         cluster_id = centroidid)
 
 
 
@@ -135,14 +135,12 @@ survey_regions %>%
 
 survey_clusters <- hh %>%
   transmute(survey_id = survey_id,
-            cluster_id = paste(varstrat, varunit),
+            cluster_id = centroidid,
             cluster_id,
             res_type = factor(urban, 1:2, c("urban", "rural")),
-            survey_region_id,
-            centroidid) %>%
+            survey_region_id) %>%
   distinct() %>%
-  left_join(geo, by = "centroidid") %>%
-  select(-centroidid) %>%
+  left_join(geo, by = c("cluster_id" = "centroidid")) %>%
   sf::st_as_sf(coords = c("longitude", "latitude"), remove = FALSE) %>%
   sf::`st_crs<-`(4326)
 

--- a/src/swz_survey_phia/orderly.yml
+++ b/src/swz_survey_phia/orderly.yml
@@ -1,0 +1,33 @@
+script: script.R
+
+artefacts:
+  - data:
+      description: SHIMS2 2016-17 survey microdata
+      filenames:
+        - swz2017phia_survey_meta.csv
+        - swz2017phia_survey_regions.csv
+        - swz2017phia_survey_clusters.csv
+        - swz2017phia_survey_individuals.csv
+        - swz2017phia_survey_biomarker.csv
+        - swz2017phia_survey_circumcision.csv
+  - staticgraph:
+       description: SHIMS2 survey regions vs. area hierarchy
+       filenames:
+         - check/swz-phia-survey-region-boundaries.png
+
+packages:
+  - dplyr
+  - ggplot2
+  - haven
+  - naomi
+  - spud
+  - rdhs
+  - readr
+  - sf
+
+depends:
+  swz_data_areas:
+    id: latest
+    use:
+      depends/swz_areas.geojson: swz_areas.geojson
+  

--- a/src/swz_survey_phia/script.R
+++ b/src/swz_survey_phia/script.R
@@ -1,0 +1,332 @@
+
+#' ## Survey meta data
+
+iso3 <- "SWZ"
+country <- "Eswatini"
+survey_id  <- "SWZ2016PHIA"
+survey_mid_calendar_quarter <- "CY2017Q1"
+fieldwork_start <- NA
+fieldwork_end <- NA
+
+
+#' ## Load area hierarchy
+areas <- read_sf("depends/swz_areas.geojson")
+
+
+#' ## Load PHIA datasets
+sharepoint <- spud::sharepoint$new("https://imperiallondon.sharepoint.com/")
+
+phia_path <- "sites/HIVInferenceGroup-WP/Shared Documents/Data/household surveys/PHIA/datasets/SWZ/datasets"
+
+paths <- list(geo = "SHIMS2 2016-2017 PR Geospatial Data 20211022.zip",
+              survey = "SHIMS2 2016-2017 Household Interview and Biomarker Datasets v2.0 (DTA).zip") %>%
+  lapply(function(x) file.path(phia_path, x)) %>%
+  lapply(URLencode)
+
+phia_files <- lapply(paths, sharepoint$download)
+
+geo <- rdhs::read_zipdata(phia_files$geo)
+
+hh <- rdhs::read_zipdata(phia_files$survey, "shims22016hh.dta")
+bio <- rdhs::read_zipdata(phia_files$survey, "shims22016adultbio.dta")
+ind <- rdhs::read_zipdata(phia_files$survey, "shims22016adultind.dta")
+chbio <- rdhs::read_zipdata(phia_files$survey, "shims22016childbio.dta")
+chind <- rdhs::read_zipdata(phia_files$survey, "shims22016childind.dta")
+
+
+#' Note: religion and ethnicity not asked
+
+phia <- ind %>%
+  filter(indstatus == 1) %>%  # Respondent
+  select(centroidid, region, urban, householdid,
+         personid, surveystyear, surveystmonth,
+         intwt0, gender, age,
+         mcstatus, mcage, mcwho) %>%
+  full_join(
+    bio %>%
+    filter(bt_status == 1) %>%
+    select(personid, btwt0, hivstatusfinal, arvstatus, artselfreported,
+           vls, cd4count, recentlagvlarv),
+    by = "personid"
+  ) %>%
+  mutate(survey_id = survey_id,
+         cluster_id = centroidid)
+
+chphia <- chind %>%
+  filter(indstatus == 1) %>%
+  select(centroidid, region, urban, householdid,
+         personid, surveystyear, surveystmonth,
+         intwt0, gender, age, agem) %>%
+  full_join(
+    chbio %>%
+    filter(bt_status == 1) %>%
+    select(personid, btwt0, hivstatusfinal, arvstatus, pedartparentreported,
+           vls, cd4count, recentlagvlarv),
+    by = "personid"
+  ) %>%
+  mutate(survey_id = survey_id,
+         cluster_id = centroidid)
+
+
+
+#' ## Survey regions
+#'
+#' This table identifies the smallest area in the area hierarchy which contains each
+#' region in the survey stratification, which is the smallest area to which a cluster
+#' can be assigned with certainty.
+
+hh$survey_region_id <- hh$region # different in each survey dataset depending on survey stratification
+
+survey_region_id <- c("Hhohho" = 1,
+                      "Lubombo" = 2,
+                      "Manzini" = 3,
+                      "Shiselweni" = 4)
+
+survey_region_area_id <- c("Hhohho" = "SWZ_1_1",
+                           "Lubombo" = "SWZ_1_2",
+                           "Manzini" = "SWZ_1_3",
+                           "Shiselweni" = "SWZ_1_4")
+
+survey_regions <- tibble(survey_id = survey_id,
+                         survey_region_id = survey_region_id,
+                         survey_region_name = names(survey_region_id),
+                         survey_region_area_id = survey_region_area_id[names(survey_region_id)])
+
+#' Add survey region boundary
+
+survey_regions <- survey_regions %>%
+  left_join(
+    areas %>% select(survey_region_area_id = area_id)
+  ) %>%
+  st_as_sf()
+
+p_survey_regions <- ggplot(survey_regions) +
+  geom_sf(aes(fill = survey_region_name), color = "grey60", alpha = 0.6) +
+  geom_sf(data = areas %>% filter(area_level == 1), fill = NA, inherit.aes = FALSE)
+
+dir.create("check")
+ggsave("check/swz-phia-survey-region-boundaries.png", p_survey_regions, h = 7, w = 7)
+
+#' Inspect area_id assigments to confirm
+
+survey_regions %>%
+  left_join(
+    areas %>%
+    as.data.frame() %>%
+    select(area_id, area_name, area_level, area_level_label),
+    by = c("survey_region_area_id" = "area_id")
+  )
+
+
+#' *** Should not require edits beyond this point ***
+
+#' ## Survey clusters dataset
+#'
+#' This data frame maps survey clusters to the highest level in the area hiearchy
+#' based on geomasked cluster centroids, additionally checking that the geolocated
+#' areas are contained in the survey region.
+
+survey_clusters <- hh %>%
+  transmute(survey_id = survey_id,
+            cluster_id = centroidid,
+            cluster_id,
+            res_type = factor(urban, 1:2, c("urban", "rural")),
+            survey_region_id) %>%
+  distinct() %>%
+  left_join(geo, by = c("cluster_id" = "centroidid")) %>%
+  sf::st_as_sf(coords = c("longitude", "latitude"), remove = FALSE) %>%
+  sf::`st_crs<-`(4326)
+
+
+#' Snap clusters to areas
+#' 
+#' This is slow because it maps to the lowest level immediately
+#' It would be more efficient to do this recursively through
+#' the location hierarchy tree -- but not worth the effort right now.
+
+#' Create a list of all of the areas within each survey region
+#' (These are the candidate areas where a cluster could be located)
+
+survey_region_areas  <- survey_regions %>%
+  st_join(
+    st_point_on_surface(areas) %>%
+    filter(area_level == max(area_level)) %>%
+    select(area_id)
+  ) %>%
+  st_set_geometry(NULL) %>%
+  left_join(
+    areas %>% select(area_id, geometry),
+    by = "area_id"
+  ) %>%
+  select(survey_region_id, area_id, geometry_area = geometry)
+
+#' Calculate distance to each candidate area for each cluster
+
+survey_clusters <- survey_clusters %>%
+  left_join(survey_region_areas, by = "survey_region_id") %>%
+  mutate(
+    distance = unlist(Map(sf::st_distance, geometry, geometry_area))
+  )
+
+#' Keep the area with the smallest distance from cluster centroid.
+#' (Should be 0 for almost all)
+
+survey_clusters <- survey_clusters %>%
+  arrange(distance) %>%
+  group_by(survey_id, cluster_id) %>%
+  filter(row_number() == 1) %>%
+  ungroup() %>%
+  as.data.frame() %>%
+  transmute(survey_id,
+            cluster_id,
+            res_type,
+            survey_region_id,
+            longitude,
+            latitude,
+            geoloc_area_id = area_id,
+            geoloc_distance = distance)
+
+#' Review clusters outside admin area
+
+survey_clusters %>%
+  filter(geoloc_distance > 0) %>%
+  arrange(-geoloc_distance) %>%
+  left_join(survey_regions) 
+
+#' ## Survey individuals dataset
+
+mcstatus_lables <- c(`1` = "Yes",
+                     `2` = "No",
+                     `-8` = "Don't know",
+                     `-9` = "Refused")
+
+mcwho_labels = c(`1` = "Doctor, clinical officer, or nurse",
+                 `2` = "Traditional practitioner / circumciser",
+                 `3` = "Midwife",
+                 `4` = "Family/Friend",
+                 `96` = "Other",
+                 `-8` = "Don't know",
+                 `-9` = "Refused")
+
+mcwho_recode = c(`1` = "Healthcare worker",
+                 `2` = "Traditional practitioner",
+                 `3` = "Traditional practitioner",   ## TODO: UNSURE ON THIS
+                 `4` = "Traditional practitioner",   ## TODO: UNSURE ON THIS
+                 `96` = "Traditional practitioner",
+                 `-8` = NA_character_,
+                 `-9` = NA_character_)
+
+
+#' Create individuals data
+
+survey_individuals <-
+  bind_rows(
+    phia %>%
+    transmute(
+      survey_id,
+      cluster_id,
+      individual_id = personid,
+      household = householdid,
+      line = personid,
+      interview_cmc = 12 * (surveystyear - 1900) + surveystmonth,
+      sex = factor(gender, 1:2, c("male", "female")),
+      age,
+      dob_cmc = NA,
+      indweight = intwt0
+    ),
+    chphia %>%
+    transmute(
+      survey_id,
+      cluster_id,
+      individual_id = personid,
+      household = householdid,
+      line = personid,
+      interview_cmc = 12 * (surveystyear - 1900) + surveystmonth,
+      sex = factor(gender, 1:2, c("male", "female")),
+      age,
+      dob_cmc = interview_cmc - agem,
+      indweight = intwt0
+    )
+  ) %>%
+  mutate(age = as.integer(age),
+         indweight = indweight / mean(indweight, na.rm=TRUE)) 
+
+
+survey_biomarker <-
+  bind_rows(
+    phia %>%
+    filter(!is.na(hivstatusfinal)) %>%
+    transmute(
+      survey_id,
+      individual_id = personid,
+      hivweight = btwt0,
+      hivstatus = case_when(hivstatusfinal == 1 ~ 1,
+                            hivstatusfinal == 2 ~ 0),
+      arv = case_when(arvstatus == 1 ~ 1,
+                      arvstatus == 2 ~ 0),
+      artself = case_when(artselfreported == 1 ~ 1,
+                          artselfreported == 2 ~ 0),
+      vls = case_when(vls == 1 ~ 1,
+                      vls == 2 ~ 0),
+      cd4 = cd4count,
+      recent = case_when(recentlagvlarv == 1 ~ 1,
+                         recentlagvlarv == 2 ~ 0)
+    )
+   ,
+    chphia %>%
+    filter(!is.na(hivstatusfinal)) %>%
+    transmute(
+      survey_id,
+      individual_id = personid,
+      hivweight = btwt0,
+      hivstatus = case_when(hivstatusfinal == 1 ~ 1,
+                            hivstatusfinal == 2 ~ 0),
+      arv = case_when(arvstatus == 1 ~ 1,
+                      arvstatus == 2 ~ 0),
+      artself = case_when(pedartparentreported == 1 ~ 1,
+                          pedartparentreported == 2 ~ 0),
+      vls = case_when(vls == 1 ~ 1,
+                      vls == 2 ~ 0),
+      cd4 = cd4count,
+      recent = case_when(recentlagvlarv == 1 ~ 1,
+                         recentlagvlarv == 2 ~ 0)
+    )
+  ) %>%
+  mutate(hivweight = hivweight / mean(hivweight, na.rm = TRUE))
+
+
+survey_circumcision <- phia %>%
+  filter(gender == 1) %>%
+  transmute(
+    survey_id,
+    individual_id = personid,
+    circumcised = recode(mcstatus, `2` = 0L , `1` = 1L, .default = NA_integer_),
+    circ_age = mcage,
+    circ_where = NA_character_,
+    circ_who = recode(mcwho, !!!mcwho_recode)
+  )
+
+
+
+survey_meta <- survey_individuals %>%
+  group_by(survey_id) %>%
+  summarise(female_age_min = min(if_else(sex == "female", age, NA_integer_), na.rm=TRUE),
+            female_age_max = max(if_else(sex == "female", age, NA_integer_), na.rm=TRUE),
+            male_age_min = min(if_else(sex == "male", age, NA_integer_), na.rm=TRUE),
+            male_age_max = max(if_else(sex == "male", age, NA_integer_), na.rm=TRUE),
+            .groups = "drop") %>%
+  mutate(iso3 = substr(survey_id, 1, 3),
+         country = country,
+         survey_type = "PHIA",
+         survey_mid_calendar_quarter = recode(iso3, "MWI" = survey_mid_calendar_quarter),
+         fieldwork_start = fieldwork_start,
+         fieldwork_end   = fieldwork_end)
+
+#' ## Save survey datasets
+
+write_csv(survey_meta, paste0(tolower(survey_id), "_survey_meta.csv"), na = "")
+write_csv(survey_regions, paste0(tolower(survey_id), "_survey_regions.csv"), na = "")
+write_csv(survey_clusters, paste0(tolower(survey_id), "_survey_clusters.csv"), na = "")
+write_csv(survey_individuals, paste0(tolower(survey_id), "_survey_individuals.csv"), na = "")
+write_csv(survey_biomarker, paste0(tolower(survey_id), "_survey_biomarker.csv"), na = "")
+write_csv(survey_circumcision, paste0(tolower(survey_id), "_survey_circumcision.csv"), na = "")

--- a/src/swz_survey_phia/script.R
+++ b/src/swz_survey_phia/script.R
@@ -3,7 +3,7 @@
 
 iso3 <- "SWZ"
 country <- "Eswatini"
-survey_id  <- "SWZ2016PHIA"
+survey_id  <- "SWZ2017PHIA"
 survey_mid_calendar_quarter <- "CY2017Q1"
 fieldwork_start <- NA
 fieldwork_end <- NA

--- a/src/tza_survey/orderly.yml
+++ b/src/tza_survey/orderly.yml
@@ -18,6 +18,7 @@ packages:
   - naomi
   - naomi.utils
   - rdhs
+  - readr
   - sf
 
 depends:

--- a/src/tza_survey_phia/orderly.yml
+++ b/src/tza_survey_phia/orderly.yml
@@ -1,0 +1,33 @@
+script: script.R
+
+artefacts:
+  - data:
+      description: THIS 2016-17 survey microdata
+      filenames:
+        - tza2016phia_survey_meta.csv
+        - tza2016phia_survey_regions.csv
+        - tza2016phia_survey_clusters.csv
+        - tza2016phia_survey_individuals.csv
+        - tza2016phia_survey_biomarker.csv
+        - tza2016phia_survey_circumcision.csv
+  - staticgraph:
+       description:  TZA PHIA survey regions 
+       filenames:
+         - check/tza-phia-survey-region-boundaries.png
+
+packages:
+  - dplyr
+  - ggplot2
+  - haven
+  - naomi
+  - spud
+  - rdhs
+  - readr
+  - sf
+
+depends:
+  tza_data_areas:
+    id: latest
+    use:
+      depends/tza_areas.geojson: tza_areas.geojson
+  

--- a/src/tza_survey_phia/script.R
+++ b/src/tza_survey_phia/script.R
@@ -1,0 +1,333 @@
+
+#' ## Survey meta data
+
+iso3 <- "TZA"
+country <- "Tanzania"
+survey_id  <- "TZA2016PHIA"
+survey_mid_calendar_quarter <- "CY2016Q4"
+fieldwork_start <- NA
+fieldwork_end <- NA
+
+
+#' ## Load area hierarchy
+areas <- read_sf("depends/tza_areas.geojson")
+
+
+#' ## Load PHIA datasets
+sharepoint <- spud::sharepoint$new("https://imperiallondon.sharepoint.com/")
+
+phia_path <- "sites/HIVInferenceGroup-WP/Shared Documents/Data/household surveys/PHIA/datasets/TZA/datasets"
+
+paths <- list(geo = "THIS 2016-2017 PR Geospatial Data 20211014.zip",
+              survey = "THIS 2016-2017 Household Interview and Biomarker Datasets v2.0 (DTA).zip") %>%
+  lapply(function(x) file.path(phia_path, x)) %>%
+  lapply(URLencode)
+
+phia_files <- lapply(paths, sharepoint$download)
+
+geo <- rdhs::read_zipdata(phia_files$geo)
+
+hh <- rdhs::read_zipdata(phia_files$survey, "this2016hh.dta")
+bio <- rdhs::read_zipdata(phia_files$survey, "this2016adultbio.dta")
+ind <- rdhs::read_zipdata(phia_files$survey, "this2016adultind.dta")
+chbio <- rdhs::read_zipdata(phia_files$survey, "this2016childbio.dta")
+chind <- rdhs::read_zipdata(phia_files$survey, "this2016childind.dta")
+
+
+#' Note: Religion and ethnicity  not asked.
+#' 
+
+phia <- ind %>%
+  filter(indstatus == 1) %>%  # Respondent
+  select(centroidid, region, urban, householdid,
+         personid, surveystyear, surveystmonth,
+         intwt0, gender, age,
+         mcstatus, mcage, mcwho) %>%
+  full_join(
+    bio %>%
+    filter(bt_status == 1) %>%
+    select(personid, btwt0, hivstatusfinal, arvstatus, artselfreported,
+           vls, cd4count, recentlagvlarv),
+    by = "personid"
+  ) %>%
+  mutate(survey_id = survey_id,
+         cluster_id = centroidid)
+
+chphia <- chind %>%
+  filter(indstatus == 1) %>%
+  select(centroidid, region, urban, householdid,
+         personid, surveystyear, surveystmonth,
+         intwt0, gender, age, agem) %>%
+  full_join(
+    chbio %>%
+    filter(bt_status == 1) %>%
+    select(personid, btwt0, hivstatusfinal, arvstatus, pedartparentreported,
+           vls, cd4count, recentlagvlarv),
+    by = "personid"
+  ) %>%
+  mutate(survey_id = survey_id,
+         cluster_id = centroidid)
+
+
+
+#' ## Survey regions
+#'
+#' This table identifies the smallest area in the area hierarchy which contains each
+#' region in the survey stratification, which is the smallest area to which a cluster
+#' can be assigned with certainty.
+
+hh$survey_region_id <- hh$region # different in each survey dataset depending on survey stratification
+
+survey_region_id <- c("Dodoma" = 1, "Arusha" = 2, "Kilimanjaro" = 3, "Tanga" = 4,
+                      "Morogoro" = 5, "Pwani" = 6, "Dar-es-salaam" = 7, "Lindi" = 8,
+                      "Mtwara" = 9, "Ruvuma" = 10, "Iringa" = 11, "Mbeya" = 12,
+                      "Singida" = 13, "Tabora" = 14, "Rukwa" = 15, "Kigoma" = 16,
+                      "Shinyanga" = 17, "Kagera" = 18, "Mwanza" = 19, "Mara" = 20,
+                      "Manyara" = 21, "Njombe" = 22, "Katavi" = 23, "Simiyu" = 24,
+                      "Geita" = 25, "Songwe" = 26,
+                      "Kaskazini Unguja" = 51, "Kusini Unguja" = 52,
+                      "Mjini Magharibi" = 53, "Kaskazini Pemba" = 54,
+                      "Kusini Pemba" = 55)
+
+survey_regions <- areas %>%
+  filter(area_level == 2) %>%
+  select(survey_region_area_id = area_id,
+         survey_region_name = area_name) %>%
+  full_join(
+    tibble(survey_id = survey_id,
+           survey_region_name = names(survey_region_id),
+           survey_region_id = survey_region_id)
+  ) %>%
+  select(survey_id, survey_region_id, survey_region_name, survey_region_area_id)
+
+p_survey_regions <- ggplot(survey_regions) +
+  geom_sf(aes(fill = survey_region_name), color = "grey60", alpha = 0.6) +
+  geom_sf(data = areas %>% filter(area_level == 1), fill = NA, inherit.aes = FALSE)
+
+dir.create("check")
+ggsave("check/tza-phia-survey-region-boundaries.png", p_survey_regions, h = 7, w = 7)
+
+
+#' Inspect area_id assigments to confirm
+
+survey_regions %>%
+  left_join(
+    areas %>%
+    as.data.frame() %>%
+    select(area_id, area_name, area_level, area_level_label),
+    by = c("survey_region_area_id" = "area_id")
+  )
+
+
+#' *** Should not require edits beyond this point ***
+
+#' ## Survey clusters dataset
+#'
+#' This data frame maps survey clusters to the highest level in the area hiearchy
+#' based on geomasked cluster centroids, additionally checking that the geolocated
+#' areas are contained in the survey region.
+
+survey_clusters <- hh %>%
+  transmute(survey_id = survey_id,
+            cluster_id = centroidid,
+            cluster_id,
+            res_type = factor(urban, 1:2, c("urban", "rural")),
+            survey_region_id) %>%
+  distinct() %>%
+  left_join(geo, by = c("cluster_id" = "centroidid")) %>%
+  sf::st_as_sf(coords = c("longitude", "latitude"), remove = FALSE) %>%
+  sf::`st_crs<-`(4326)
+
+
+#' Snap clusters to areas
+#' 
+#' This is slow because it maps to the lowest level immediately
+#' It would be more efficient to do this recursively through
+#' the location hierarchy tree -- but not worth the effort right now.
+
+#' Create a list of all of the areas within each survey region
+#' (These are the candidate areas where a cluster could be located)
+
+survey_region_areas  <- survey_regions %>%
+  st_join(
+    st_point_on_surface(areas) %>%
+    filter(area_level == max(area_level)) %>%
+    select(area_id)
+  ) %>%
+  st_set_geometry(NULL) %>%
+  left_join(
+    areas %>% select(area_id, geometry),
+    by = "area_id"
+  ) %>%
+  select(survey_region_id, area_id, geometry_area = geometry)
+
+#' Calculate distance to each candidate area for each cluster
+
+survey_clusters <- survey_clusters %>%
+  left_join(survey_region_areas, by = "survey_region_id") %>%
+  mutate(
+    distance = unlist(Map(sf::st_distance, geometry, geometry_area))
+  )
+
+#' Keep the area with the smallest distance from cluster centroid.
+#' (Should be 0 for almost all)
+
+survey_clusters <- survey_clusters %>%
+  arrange(distance) %>%
+  group_by(survey_id, cluster_id) %>%
+  filter(row_number() == 1) %>%
+  ungroup() %>%
+  as.data.frame() %>%
+  transmute(survey_id,
+            cluster_id,
+            res_type,
+            survey_region_id,
+            longitude,
+            latitude,
+            geoloc_area_id = area_id,
+            geoloc_distance = distance)
+
+#' Review clusters outside admin area
+
+survey_clusters %>%
+  filter(geoloc_distance > 0) %>%
+  arrange(-geoloc_distance) %>%
+  left_join(survey_regions) 
+
+#' ## Survey individuals dataset
+
+mcstatus_lables <- c(`1` = "Yes",
+                     `2` = "No",
+                     `-8` = "Don't know",
+                     `-9` = "Refused")
+
+mcwho_labels = c(`1` = "Doctor, clinical officer, or nurse",
+                 `2` = "Traditional practitioner / circumciser",
+                 `3` = "Midwife",
+                 `4` = "Family/Friend",
+                 `96` = "Other",
+                 `-8` = "Don't know",
+                 `-9` = "Refused")
+
+mcwho_recode = c(`1` = "Healthcare worker",
+                 `2` = "Traditional practitioner",
+                 `3` = "Traditional practitioner",   ## TODO: UNSURE ON THIS
+                 `4` = "Traditional practitioner",   ## TODO: UNSURE ON THIS
+                 `96` = "Traditional practitioner",
+                 `-8` = NA_character_,
+                 `-9` = NA_character_)
+
+
+#' Create individuals data
+
+survey_individuals <-
+  bind_rows(
+    phia %>%
+    transmute(
+      survey_id,
+      cluster_id,
+      individual_id = personid,
+      household = householdid,
+      line = personid,
+      interview_cmc = 12 * (surveystyear - 1900) + surveystmonth,
+      sex = factor(gender, 1:2, c("male", "female")),
+      age,
+      dob_cmc = NA,
+      indweight = intwt0
+    ),
+    chphia %>%
+    transmute(
+      survey_id,
+      cluster_id,
+      individual_id = personid,
+      household = householdid,
+      line = personid,
+      interview_cmc = 12 * (surveystyear - 1900) + surveystmonth,
+      sex = factor(gender, 1:2, c("male", "female")),
+      age,
+      dob_cmc = interview_cmc - agem,
+      indweight = intwt0
+    )
+  ) %>%
+  mutate(age = as.integer(age),
+         indweight = indweight / mean(indweight, na.rm=TRUE)) 
+
+
+survey_biomarker <-
+  bind_rows(
+    phia %>%
+    filter(!is.na(hivstatusfinal)) %>%
+    transmute(
+      survey_id,
+      individual_id = personid,
+      hivweight = btwt0,
+      hivstatus = case_when(hivstatusfinal == 1 ~ 1,
+                            hivstatusfinal == 2 ~ 0),
+      arv = case_when(arvstatus == 1 ~ 1,
+                      arvstatus == 2 ~ 0),
+      artself = case_when(artselfreported == 1 ~ 1,
+                          artselfreported == 2 ~ 0),
+      vls = case_when(vls == 1 ~ 1,
+                      vls == 2 ~ 0),
+      cd4 = cd4count,
+      recent = case_when(recentlagvlarv == 1 ~ 1,
+                         recentlagvlarv == 2 ~ 0)
+    )
+   ,
+    chphia %>%
+    filter(!is.na(hivstatusfinal)) %>%
+    transmute(
+      survey_id,
+      individual_id = personid,
+      hivweight = btwt0,
+      hivstatus = case_when(hivstatusfinal == 1 ~ 1,
+                            hivstatusfinal == 2 ~ 0),
+      arv = case_when(arvstatus == 1 ~ 1,
+                      arvstatus == 2 ~ 0),
+      artself = case_when(pedartparentreported == 1 ~ 1,
+                          pedartparentreported == 2 ~ 0),
+      vls = case_when(vls == 1 ~ 1,
+                      vls == 2 ~ 0),
+      cd4 = cd4count,
+      recent = case_when(recentlagvlarv == 1 ~ 1,
+                         recentlagvlarv == 2 ~ 0)
+    )
+  ) %>%
+  mutate(hivweight = hivweight / mean(hivweight, na.rm = TRUE))
+
+
+survey_circumcision <- phia %>%
+  filter(gender == 1) %>%
+  transmute(
+    survey_id,
+    individual_id = personid,
+    circumcised = recode(mcstatus, `2` = 0L , `1` = 1L, .default = NA_integer_),
+    circ_age = mcage,
+    circ_where = NA_character_,
+    circ_who = recode(mcwho, !!!mcwho_recode)
+  )
+
+
+
+survey_meta <- survey_individuals %>%
+  group_by(survey_id) %>%
+  summarise(female_age_min = min(if_else(sex == "female", age, NA_integer_), na.rm=TRUE),
+            female_age_max = max(if_else(sex == "female", age, NA_integer_), na.rm=TRUE),
+            male_age_min = min(if_else(sex == "male", age, NA_integer_), na.rm=TRUE),
+            male_age_max = max(if_else(sex == "male", age, NA_integer_), na.rm=TRUE),
+            .groups = "drop") %>%
+  mutate(iso3 = substr(survey_id, 1, 3),
+         country = country,
+         survey_type = "PHIA",
+         survey_mid_calendar_quarter = recode(iso3, "MWI" = survey_mid_calendar_quarter),
+         fieldwork_start = fieldwork_start,
+         fieldwork_end   = fieldwork_end)
+
+#' ## Save survey datasets
+
+write_csv(survey_meta, paste0(tolower(survey_id), "_survey_meta.csv"), na = "")
+write_csv(survey_regions, paste0(tolower(survey_id), "_survey_regions.csv"), na = "")
+write_csv(survey_clusters, paste0(tolower(survey_id), "_survey_clusters.csv"), na = "")
+write_csv(survey_individuals, paste0(tolower(survey_id), "_survey_individuals.csv"), na = "")
+write_csv(survey_biomarker, paste0(tolower(survey_id), "_survey_biomarker.csv"), na = "")
+write_csv(survey_circumcision, paste0(tolower(survey_id), "_survey_circumcision.csv"), na = "")

--- a/src/uga_survey_phia/orderly.yml
+++ b/src/uga_survey_phia/orderly.yml
@@ -1,0 +1,33 @@
+script: script.R
+
+artefacts:
+  - data:
+      description: UPHIA 2016-17 survey microdata
+      filenames:
+        - uga2016phia_survey_meta.csv
+        - uga2016phia_survey_regions.csv
+        - uga2016phia_survey_clusters.csv
+        - uga2016phia_survey_individuals.csv
+        - uga2016phia_survey_biomarker.csv
+        - uga2016phia_survey_circumcision.csv
+  - staticgraph:
+       description: UPHIA survey regions vs. area hierarchy
+       filenames:
+         - check/uphia-survey-region-boundaries.png
+
+packages:
+  - dplyr
+  - ggplot2
+  - haven
+  - naomi
+  - spud
+  - rdhs
+  - readr
+  - sf
+
+depends:
+  uga_data_areas:
+    id: latest
+    use:
+      depends/uga_areas.geojson: uga_areas.geojson
+  

--- a/src/uga_survey_phia/script.R
+++ b/src/uga_survey_phia/script.R
@@ -1,0 +1,391 @@
+
+#' ## Survey meta data
+
+iso3 <- "UGA"
+country <- "Uganda"
+survey_id  <- "UGA2016PHIA"
+survey_mid_calendar_quarter <- "CY2016Q4"
+fieldwork_start <- NA
+fieldwork_end <- NA
+
+
+#' ## Load area hierarchy
+areas <- read_sf("depends/uga_areas.geojson")
+
+
+#' ## Load PHIA datasets
+sharepoint <- spud::sharepoint$new("https://imperiallondon.sharepoint.com/")
+
+phia_path <- "sites/HIVInferenceGroup-WP/Shared Documents/Data/household surveys/PHIA/datasets/UGA/datasets"
+
+paths <- list(geo = "UPHIA 2016-2017 PR Geospatial Data 20210602.zip",
+              hh = "102 UPHIA 2016-2017 Household Dataset (DTA).zip",
+              ind = "202 UPHIA 2016-2017 Adult Interview Dataset (DTA).zip",
+              bio = "302 UPHIA 2016-2017 Adult Biomarker Dataset (DTA).zip",
+              chind = "205 UPHIA 2016-2017 Child Interview Dataset (DTA).zip",
+              chbio = "305 UPHIA 2016-2017 Child Biomarker Dataset (DTA).zip") %>%
+  lapply(function(x) file.path(phia_path, x)) %>%
+  lapply(URLencode)
+
+phia_files <- lapply(paths, sharepoint$download)
+
+geo <- rdhs::read_zipdata(phia_files$geo)
+
+hh <- rdhs::read_zipdata(phia_files$hh)
+bio <- rdhs::read_zipdata(phia_files$bio)
+ind <- rdhs::read_zipdata(phia_files$ind)
+chbio <- rdhs::read_zipdata(phia_files$chbio)
+chind <- rdhs::read_zipdata(phia_files$chind)
+
+
+phia <- ind %>%
+  filter(indstatus == 1) %>%  # Respondent
+  select(centroidid, region, urban, householdid,
+         personid, surveystyear, surveystmonth,
+         intwt0, gender, age, religion, ethnic,
+         mcstatus, mcage, mcwho) %>%
+  full_join(
+    bio %>%
+    filter(bt_status == 1) %>%
+    select(personid, btwt0, hivstatusfinal, arvstatus, artselfreported,
+           vls, cd4count, recentlagvlarv),
+    by = "personid"
+  ) %>%
+  mutate(survey_id = survey_id,
+         cluster_id = centroidid)
+
+chphia <- chind %>%
+  filter(indstatus == 1) %>%
+  select(centroidid, region, urban, householdid,
+         personid, surveystyear, surveystmonth,
+         intwt0, gender, age, agem) %>%
+  full_join(
+    chbio %>%
+    filter(bt_status == 1) %>%
+    select(personid, btwt0, hivstatusfinal, arvstatus, pedartparentreported,
+           vls, cd4count, recentlagvlarv),
+    by = "personid"
+  ) %>%
+  mutate(survey_id = survey_id,
+         cluster_id = centroidid)
+
+
+
+#' ## Survey regions
+#'
+#' This table identifies the smallest area in the area hierarchy which contains each
+#' region in the survey stratification, which is the smallest area to which a cluster
+#' can be assigned with certainty.
+
+hh$survey_region_id <- hh$region # different in each survey dataset depending on survey stratification
+
+survey_region_id <- c("Central1" = 1,
+                      "Central2" = 2,
+                      "Kampala" = 3,
+                      "East Central" = 4,
+                      "Mid-East" = 5,
+                      "North East" = 6,
+                      "West Nile" = 7,
+                      "Mid-North" = 8,
+                      "Mid-West" = 9,
+                      "South West" = 10)
+
+areas %>% filter(area_level == 1) %>% select(area_id, area_name)
+
+survey_region_area_id <- c("Central1" = "UGA_1_09",
+                           "Central2" = "UGA_1_08",
+                           "Kampala" = "UGA_1_06",  
+                           "East Central" = "UGA_1_05",
+                           "Mid-East" = "UGA_1_03",
+                           "North East" = "UGA_1_07",
+                           "West Nile" = "UGA_1_10",
+                           "Mid-North" = "UGA_1_01",
+                           "Mid-West" = "UGA_1_04",
+                           "South West" = "UGA_1_02")
+
+survey_regions <- tibble(survey_id = survey_id,
+                         survey_region_id = survey_region_id,
+                         survey_region_name = names(survey_region_id),
+                         survey_region_area_id = survey_region_area_id[names(survey_region_id)])
+
+
+#' Add survey region boundary
+
+survey_regions <- survey_regions %>%
+  left_join(
+    areas %>% select(survey_region_area_id = area_id),
+    by = "survey_region_area_id"
+  ) %>%
+  st_as_sf()
+
+p_survey_regions <- ggplot(survey_regions) +
+  geom_sf(aes(fill = survey_region_name),
+          color = "grey60", alpha = 0.6) +
+  geom_sf(data = areas %>% filter(area_level == 1),
+          fill = NA, inherit.aes = FALSE) +
+  ggtitle("UPHIA survey regions",
+          "Survey regions (shaded) and area hierarchy level 1 (boundaries)") +
+  naomi::th_map()
+
+dir.create("check")
+ggsave("check/uphia-survey-region-boundaries.png", p_survey_regions, h = 7, w = 7)
+
+
+#' Inspect area_id assigments to confirm
+
+survey_regions %>%
+  left_join(
+    areas %>%
+    as.data.frame() %>%
+    select(area_id, area_name, area_level, area_level_label),
+    by = c("survey_region_area_id" = "area_id")
+  ) %>%
+  st_drop_geometry()
+
+
+#' *** Should not require edits beyond this point ***
+
+#' ## Survey clusters dataset
+#'
+#' This data frame maps survey clusters to the highest level in the area hiearchy
+#' based on geomasked cluster centroids, additionally checking that the geolocated
+#' areas are contained in the survey region.
+
+survey_clusters <- hh %>%
+  transmute(survey_id = survey_id,
+            cluster_id = centroidid,
+            cluster_id,
+            res_type = factor(urban, 1:2, c("urban", "rural")),
+            survey_region_id) %>%
+  distinct() %>%
+  left_join(geo, by = c("cluster_id" = "centroidid")) %>%
+  sf::st_as_sf(coords = c("longitude", "latitude"), remove = FALSE) %>%
+  sf::`st_crs<-`(4326)
+
+
+#' Snap clusters to areas
+#' 
+#' This is slow because it maps to the lowest level immediately
+#' It would be more efficient to do this recursively through
+#' the location hierarchy tree -- but not worth the effort right now.
+
+#' Create a list of all of the areas within each survey region
+#' (These are the candidate areas where a cluster could be located)
+
+survey_region_areas  <- survey_regions %>%
+  st_join(
+    st_point_on_surface(areas) %>%
+    filter(area_level == max(area_level)) %>%
+    select(area_id)
+  ) %>%
+  st_set_geometry(NULL) %>%
+  left_join(
+    areas %>% select(area_id, geometry),
+    by = "area_id"
+  ) %>%
+  select(survey_region_id, area_id, geometry_area = geometry)
+
+#' Calculate distance to each candidate area for each cluster
+
+survey_clusters <- survey_clusters %>%
+  left_join(survey_region_areas, by = "survey_region_id") %>%
+  mutate(
+    distance = unlist(Map(sf::st_distance, geometry, geometry_area))
+  )
+
+#' Keep the area with the smallest distance from cluster centroid.
+#' (Should be 0 for almost all)
+
+survey_clusters <- survey_clusters %>%
+  arrange(distance) %>%
+  group_by(survey_id, cluster_id) %>%
+  filter(row_number() == 1) %>%
+  ungroup() %>%
+  as.data.frame() %>%
+  transmute(survey_id,
+            cluster_id,
+            res_type,
+            survey_region_id,
+            longitude,
+            latitude,
+            geoloc_area_id = area_id,
+            geoloc_distance = distance)
+
+#' Review clusters outside admin area
+
+survey_clusters %>%
+  filter(geoloc_distance > 0) %>%
+  arrange(-geoloc_distance) %>%
+  left_join(survey_regions) 
+
+#' ## Survey individuals dataset
+
+religion_labels <- c(`1` = "Catholic",
+                     `2` = "Anglican/Protestant",
+                     `3` = "Sda",
+                     `4` = "Orthodox",
+                     `5` = "Pentecostal",
+                     `6` = "Other Christian",
+                     `7` = "Moslem",
+                     `8` = "Bahai",
+                     `9` = "Traditional",
+                     `10` = "Hindu",
+                     `11` = "None",
+                     `96` = "Other (Specify)",
+                     `-8` = "Don’t Know",
+                     `-9` = "Refused")
+
+ethnic_labels <- c(`1` = "Baganda",
+                   `2` = "Banyankore",
+                   `3` = "Iteso",
+                   `4` = "Lugbara/Madi",
+                   `5` = "Basoga",
+                   `6` = "Langi",
+                   `7` = "Bakiga",
+                   `8` = "Karimojong",
+                   `9` = "Acholi",
+                   `10` = "Bagisu/Sabiny",
+                   `11` = "Alur/Jopadhola",
+                   `12` = "Banyoro",
+                   `13` = "Batoro",
+                   `96` = "Other (Specify)",
+                   `-8` = "Don't know",
+                   `-9` = "Refused")
+
+mcstatus_lables <- c(`1` = "Yes",
+                     `2` = "No",
+                     `-8` = "Don't know",
+                     `-9` = "Refused")
+
+mcwho_labels = c(`1` = "Doctor, clinical officer, or nurse",
+                 `2` = "Traditional practitioner / circumciser",
+                 `3` = "Midwife",
+                 `4` = "Family/Friend",
+                 `96` = "Other",
+                 `-8` = "Don't know",
+                 `-9` = "Refused")
+
+mcwho_recode = c(`1` = "Healthcare worker",
+                 `2` = "Traditional practitioner",
+                 `3` = "Traditional practitioner",   ## TODO: UNSURE ON THIS
+                 `4` = "Traditional practitioner",   ## TODO: UNSURE ON THIS
+                 `96` = "Traditional practitioner",
+                 `-8` = NA_character_,
+                 `-9` = NA_character_)
+
+
+#' Create individuals data
+
+survey_individuals <-
+  bind_rows(
+    phia %>%
+    transmute(
+      survey_id,
+      cluster_id,
+      individual_id = personid,
+      household = householdid,
+      line = personid,
+      interview_cmc = 12 * (surveystyear - 1900) + surveystmonth,
+      sex = factor(gender, 1:2, c("male", "female")),
+      age,
+      dob_cmc = NA,
+      religion = recode(religion, !!!religion_labels),
+      ethnicity = recode(ethnic, !!!ethnic_labels),
+      indweight = intwt0
+    ),
+    chphia %>%
+    transmute(
+      survey_id,
+      cluster_id,
+      individual_id = personid,
+      household = householdid,
+      line = personid,
+      interview_cmc = 12 * (surveystyear - 1900) + surveystmonth,
+      sex = factor(gender, 1:2, c("male", "female")),
+      age,
+      dob_cmc = interview_cmc - agem,
+      indweight = intwt0
+    )
+  ) %>%
+  mutate(age = as.integer(age),
+         indweight = indweight / mean(indweight, na.rm=TRUE)) 
+
+
+survey_biomarker <-
+  bind_rows(
+    phia %>%
+    filter(!is.na(hivstatusfinal)) %>%
+    transmute(
+      survey_id,
+      individual_id = personid,
+      hivweight = btwt0,
+      hivstatus = case_when(hivstatusfinal == 1 ~ 1,
+                            hivstatusfinal == 2 ~ 0),
+      arv = case_when(arvstatus == 1 ~ 1,
+                      arvstatus == 2 ~ 0),
+      artself = case_when(artselfreported == 1 ~ 1,
+                          artselfreported == 2 ~ 0),
+      vls = case_when(vls == 1 ~ 1,
+                      vls == 2 ~ 0),
+      cd4 = cd4count,
+      recent = case_when(recentlagvlarv == 1 ~ 1,
+                         recentlagvlarv == 2 ~ 0)
+    )
+   ,
+    chphia %>%
+    filter(!is.na(hivstatusfinal)) %>%
+    transmute(
+      survey_id,
+      individual_id = personid,
+      hivweight = btwt0,
+      hivstatus = case_when(hivstatusfinal == 1 ~ 1,
+                            hivstatusfinal == 2 ~ 0),
+      arv = case_when(arvstatus == 1 ~ 1,
+                      arvstatus == 2 ~ 0),
+      artself = case_when(pedartparentreported == 1 ~ 1,
+                          pedartparentreported == 2 ~ 0),
+      vls = case_when(vls == 1 ~ 1,
+                      vls == 2 ~ 0),
+      cd4 = cd4count,
+      recent = case_when(recentlagvlarv == 1 ~ 1,
+                         recentlagvlarv == 2 ~ 0)
+    )
+  ) %>%
+  mutate(hivweight = hivweight / mean(hivweight, na.rm = TRUE))
+
+
+survey_circumcision <- phia %>%
+  filter(gender == 1) %>%
+  transmute(
+    survey_id,
+    individual_id = personid,
+    circumcised = recode(mcstatus, `2` = 0L , `1` = 1L, .default = NA_integer_),
+    circ_age = mcage,
+    circ_where = NA_character_,
+    circ_who = recode(mcwho, !!!mcwho_recode)
+  )
+
+
+
+survey_meta <- survey_individuals %>%
+  group_by(survey_id) %>%
+  summarise(female_age_min = min(if_else(sex == "female", age, NA_integer_), na.rm=TRUE),
+            female_age_max = max(if_else(sex == "female", age, NA_integer_), na.rm=TRUE),
+            male_age_min = min(if_else(sex == "male", age, NA_integer_), na.rm=TRUE),
+            male_age_max = max(if_else(sex == "male", age, NA_integer_), na.rm=TRUE),
+            .groups = "drop") %>%
+  mutate(iso3 = substr(survey_id, 1, 3),
+         country = country,
+         survey_type = "PHIA",
+         survey_mid_calendar_quarter = recode(iso3, "MWI" = survey_mid_calendar_quarter),
+         fieldwork_start = fieldwork_start,
+         fieldwork_end   = fieldwork_end)
+
+#' ## Save survey datasets
+
+write_csv(survey_meta, paste0(tolower(survey_id), "_survey_meta.csv"), na = "")
+write_csv(survey_regions, paste0(tolower(survey_id), "_survey_regions.csv"), na = "")
+write_csv(survey_clusters, paste0(tolower(survey_id), "_survey_clusters.csv"), na = "")
+write_csv(survey_individuals, paste0(tolower(survey_id), "_survey_individuals.csv"), na = "")
+write_csv(survey_biomarker, paste0(tolower(survey_id), "_survey_biomarker.csv"), na = "")
+write_csv(survey_circumcision, paste0(tolower(survey_id), "_survey_circumcision.csv"), na = "")

--- a/src/zmb_survey_phia/orderly.yml
+++ b/src/zmb_survey_phia/orderly.yml
@@ -1,0 +1,34 @@
+script: script.R
+
+artefacts:
+  - data:
+      description: ZamPHIA 2015-16 survey microdata
+      filenames:
+        - zmb2016phia_survey_meta.csv
+        - zmb2016phia_survey_regions.csv
+        - zmb2016phia_survey_clusters.csv
+        - zmb2016phia_survey_individuals.csv
+        - zmb2016phia_survey_biomarker.csv
+        - zmb2016phia_survey_circumcision.csv
+  - data:
+      description: PHIA survey boundary comparison
+      filenames:
+        - check/zambia-reallocated-districts.pdf
+        - check/zamphia-survey-regions.pdf
+
+packages:
+  - dplyr
+  - ggplot2
+  - haven
+  - naomi
+  - spud
+  - rdhs
+  - readr
+  - sf
+
+depends:
+  zmb_data_areas:
+    id: latest
+    use:
+      depends/zmb_areas.geojson: zmb_areas.geojson
+  

--- a/src/zmb_survey_phia/script.R
+++ b/src/zmb_survey_phia/script.R
@@ -31,7 +31,7 @@ chind <- rdhs::read_zipdata(phia_files$survey, "zamphia2016childind.dta")
 
 phia <- ind %>%
   filter(indstatus == 1) %>%  # Respondent
-  select(cluster_id, province, urban, householdid,
+  select(centroidid, province, urban, householdid,
          personid, surveystyear, surveystmonth,
          intwt0, gender, age, religion, ethniccode,
          mcstatus, mcage, mcwho) %>%

--- a/src/zmb_survey_phia/script.R
+++ b/src/zmb_survey_phia/script.R
@@ -31,7 +31,7 @@ chind <- rdhs::read_zipdata(phia_files$survey, "zamphia2016childind.dta")
 
 phia <- ind %>%
   filter(indstatus == 1) %>%  # Respondent
-  select(varstrat, varunit, province, urban, householdid,
+  select(cluster_id, province, urban, householdid,
          personid, surveystyear, surveystmonth,
          intwt0, gender, age, religion, ethniccode,
          mcstatus, mcage, mcwho) %>%
@@ -43,7 +43,7 @@ phia <- ind %>%
     by = "personid"
   ) %>%
   mutate(survey_id = survey_id,
-         cluster_id = paste(varstrat, varunit))
+         cluster_id = centroidid)
 
 
 #' Note: Religion was not asked for children. Strategy to
@@ -54,7 +54,7 @@ phia <- ind %>%
 
 chphia <- chind %>%
   filter(indstatus == 1) %>%
-  select(varstrat, varunit, province, urban, householdid,
+  select(centroidid, province, urban, householdid,
          personid, surveystyear, surveystmonth,
          intwt0, gender, age, agem) %>%
   full_join(
@@ -65,7 +65,7 @@ chphia <- chind %>%
     by = "personid"
   ) %>%
   mutate(survey_id = survey_id,
-         cluster_id = paste(varstrat, varunit))
+         cluster_id = centroidid)
 
 
 
@@ -186,14 +186,12 @@ survey_regions %>%
 
 survey_clusters <- hh %>%
   transmute(survey_id = survey_id,
-            cluster_id = paste(varstrat, varunit),
+            cluster_id = centroidid,
             cluster_id,
             res_type = factor(urban, 1:2, c("urban", "rural")),
-            survey_region_id,
-            centroidid) %>%
+            survey_region_id) %>%
   distinct() %>%
-  left_join(geo, by = "centroidid") %>%
-  select(-centroidid) %>%
+  left_join(geo, by = c("cluster_id" = "centroidid")) %>%
   sf::st_as_sf(coords = c("longitude", "latitude"), remove = FALSE) %>%
   sf::`st_crs<-`(4326)
 

--- a/src/zmb_survey_phia/script.R
+++ b/src/zmb_survey_phia/script.R
@@ -1,0 +1,415 @@
+
+iso3 <- "ZMB"
+country <- "Zambia"
+survey_id  <- "ZMB2016PHIA"
+survey_mid_calendar_quarter <- "CY2016Q2"
+
+#' ## Load area hierarchy
+areas <- read_sf("depends/zmb_areas.geojson")
+
+#' ## Load PHIA datasets
+sharepoint <- spud::sharepoint$new("https://imperiallondon.sharepoint.com/")
+
+phia_path <- "sites/HIVInferenceGroup-WP/Shared Documents/Data"
+
+paths <- list(gadm1 = "shape files/gadm/v3.6/gadm36_ZMB_1_sf.rds",
+              gadm2 = "shape files/gadm/v3.6/gadm36_ZMB_2_sf.rds",
+              geo = "household surveys/PHIA/datasets/ZMB/datasets/ZAMPHIA 2016 PR Geospatial Data 20210920.zip",
+              survey = "household surveys/PHIA/datasets/ZMB/datasets/ZAMPHIA 2016 Household Interview and Biomarker Datasets v2.0 (DTA).zip") %>%
+  lapply(function(x) file.path(phia_path, x)) %>%
+  lapply(URLencode)
+
+phia_files <- lapply(paths, sharepoint$download)
+
+geo <- rdhs::read_zipdata(phia_files$geo)
+
+hh <- rdhs::read_zipdata(phia_files$survey, "zamphia2016hh.dta")
+bio <- rdhs::read_zipdata(phia_files$survey, "zamphia2016adultbio.dta")
+ind <- rdhs::read_zipdata(phia_files$survey, "zamphia2016adultind.dta")
+chbio <- rdhs::read_zipdata(phia_files$survey, "zamphia2016childbio.dta")
+chind <- rdhs::read_zipdata(phia_files$survey, "zamphia2016childind.dta")
+
+phia <- ind %>%
+  filter(indstatus == 1) %>%  # Respondent
+  select(varstrat, varunit, province, urban, householdid,
+         personid, surveystyear, surveystmonth,
+         intwt0, gender, age, religion, ethniccode,
+         mcstatus, mcage, mcwho) %>%
+  full_join(
+    bio %>%
+    filter(bt_status == 1) %>%
+    select(personid, btwt0, hivstatusfinal, arvstatus, artselfreported,
+           vls, cd4count, recentlagvlarv),
+    by = "personid"
+  ) %>%
+  mutate(survey_id = survey_id,
+         cluster_id = paste(varstrat, varunit))
+
+
+#' Note: Religion was not asked for children. Strategy to
+#'       assign these based on `momid` if available, otherwise modal value
+#'       from the household. But the primary motivation for these variables
+#'       is for circumcision analysis, which is not asked for children.
+#'
+
+chphia <- chind %>%
+  filter(indstatus == 1) %>%
+  select(varstrat, varunit, province, urban, householdid,
+         personid, surveystyear, surveystmonth,
+         intwt0, gender, age, agem) %>%
+  full_join(
+    chbio %>%
+    filter(bt_status == 1) %>%
+    select(personid, btwt0, hivstatusfinal, arvstatus, pedartparentreported,
+           vls, cd4count, recentlagvlarv),
+    by = "personid"
+  ) %>%
+  mutate(survey_id = survey_id,
+         cluster_id = paste(varstrat, varunit))
+
+
+
+#' ## Survey regions
+#'
+#' This table identifies the smallest area in the area hierarchy which contains each
+#' region in the survey stratification, which is the smallest area to which a cluster
+#' can be assigned with certainty.
+
+hh$survey_region_id <- hh$province # different in each survey dataset depending on survey stratification
+
+survey_region_id <- c("Central" = 1, "Copperbelt" = 2, "Eastern" = 3,
+                      "Luapula" = 4, "Lusaka" = 5, "Muchinga" = 6,
+                      "Northern" = 7, "North-Western" = 8, "Southern" = 9,
+                      "Western" = 10)
+
+
+areas %>% filter(area_level == 1) %>% select(area_id, area_name)
+
+#' Note: ZAMPHIA stratification used old province boundaries from GADM.
+#'  Since then:
+#'  * Itezhi-tezhi district moved from Southern province to Central province
+#'  * Chirundu district moved from Southern province to Lusaka.
+#'  * Shibuyunji district was moved in 2018 from Lusaka to Central. But in the PHIA boundaries, Shibuyunji
+#'    area was in Central (not existing as district per GADM level 2). Thus no net change for this district.
+
+zmb_gadm1 <- readRDS(phia_files$gadm1)
+zmb_gadm2 <- readRDS(phia_files$gadm2)
+
+p1 <- ggplot() +
+  geom_sf(aes(fill = NAME_1), data = zmb_gadm1 %>% filter(NAME_1 %in% c("Central", "Southern", "Lusaka")), alpha = 0.6, color = NA) +
+  geom_sf(data = areas %>% filter(area_level == 2), fill = NA, color = "grey") +
+  geom_sf_label(aes(label = area_name),
+                data = areas %>%
+                  filter(area_level == 2,
+                         area_name %in% c("Itezhi-tezhi", "Shibuyunji", "Chirundu")),
+                alpha = 0.3) +
+  geom_sf(data = areas %>% filter(area_level == 1), fill = NA) +
+  labs(fill = "ZAMPHIA strata") +
+  theme_minimal() +
+  theme(axis.text = element_blank(),
+        axis.title = element_blank(),
+        axis.ticks = element_blank(),
+        panel.grid = element_blank(),
+        legend.position = c(0.05, 0.95),
+        legend.just = c(0, 1))
+
+dir.create("check")
+ggsave("check/zambia-reallocated-districts.pdf", p1, h = 6, w = 7)
+
+survey_region_area_id <- c("Central" = "ZMB",
+                           "Copperbelt" = "ZMB_1_11",
+                           "Eastern" = "ZMB_1_12",
+                           "Luapula" = "ZMB_1_13",
+                           "Lusaka" = "ZMB_1_14",
+                           "Muchinga" = "ZMB_1_15",
+                           "Northern" = "ZMB_1_16",
+                           "North-Western" = "ZMB_1_19",
+                           "Southern" = "ZMB",
+                           "Western" = "ZMB_1_18")
+
+survey_regions <- tibble(survey_id = survey_id,
+                         survey_region_id = survey_region_id,
+                         survey_region_name = names(survey_region_id),
+                         survey_region_area_id = survey_region_area_id[names(survey_region_id)])
+
+
+#' Add survey region boundary
+
+survey_regions <- survey_regions %>%
+  left_join(
+    spread_areas(as.data.frame(areas)) %>%
+    left_join(select(areas, area_id)) %>%
+    st_as_sf() %>%
+    mutate(survey_region_name = case_when(area_name2 == "Itezhi-tezhi" ~ "Southern",
+                                          area_name2 == "Shibuyunji" ~ "Central",
+                                          area_name2 == "Chirundu" ~ "Southern",
+                                          TRUE ~ area_name1)) %>%
+    group_by(survey_region_name) %>%
+    summarise()
+  ) %>%
+  st_as_sf()
+
+p2 <- ggplot(survey_regions) +
+  geom_sf(aes(fill = survey_region_name), color = "grey60", alpha = 0.6) +
+  geom_sf(data = areas %>% filter(area_level == 1), fill = NA, inherit.aes = FALSE) +
+  theme_minimal() +
+  theme(axis.text = element_blank(),
+        axis.title = element_blank(),
+        axis.ticks = element_blank(),
+        panel.grid = element_blank())
+
+dir.create("check")
+ggsave("check/zamphia-survey-regions.pdf", p2, h = 5, w = 7)
+
+
+
+
+#' Inspect area_id assigments to confirm
+
+survey_regions %>%
+  st_drop_geometry() %>%
+  left_join(
+    areas %>%
+    st_drop_geometry() %>%
+    select(area_id, area_name, area_level, area_level_label),
+    by = c("survey_region_area_id" = "area_id")
+  )
+
+
+#' *** Should not require edits beyond this point ***
+
+#' ## Survey clusters dataset
+#'
+#' This data frame maps survey clusters to the highest level in the area hiearchy
+#' based on geomasked cluster centroids, additionally checking that the geolocated
+#' areas are contained in the survey region.
+
+survey_clusters <- hh %>%
+  transmute(survey_id = survey_id,
+            cluster_id = paste(varstrat, varunit),
+            cluster_id,
+            res_type = factor(urban, 1:2, c("urban", "rural")),
+            survey_region_id,
+            centroidid) %>%
+  distinct() %>%
+  left_join(geo, by = "centroidid") %>%
+  select(-centroidid) %>%
+  sf::st_as_sf(coords = c("longitude", "latitude"), remove = FALSE) %>%
+  sf::`st_crs<-`(4326)
+
+
+#' Snap clusters to areas
+#'
+#' This is slow because it maps to the lowest level immediately
+#' It would be more efficient to do this recursively through
+#' the location hierarchy tree -- but not worth the effort right now.
+
+#' Create a list of all of the areas within each survey region
+#' (These are the candidate areas where a cluster could be located)
+
+survey_region_areas  <- survey_regions %>%
+  st_join(
+    st_point_on_surface(areas) %>%
+    filter(area_level == max(area_level)) %>%
+    select(area_id)
+  ) %>%
+  st_set_geometry(NULL) %>%
+  left_join(
+    areas %>% select(area_id, geometry),
+    by = "area_id"
+  ) %>%
+  select(survey_region_id, area_id, geometry_area = geometry)
+
+#' Calculate distance to each candidate area for each cluster
+
+survey_clusters <- survey_clusters %>%
+  left_join(survey_region_areas, by = "survey_region_id") %>%
+  mutate(
+    distance = unlist(Map(sf::st_distance, geometry, geometry_area))
+  )
+
+#' Keep the area with the smallest distance from cluster centroid.
+#' (Should be 0 for almost all)
+
+survey_clusters <- survey_clusters %>%
+  arrange(distance) %>%
+  group_by(survey_id, cluster_id) %>%
+  filter(row_number() == 1) %>%
+  ungroup() %>%
+  as.data.frame() %>%
+  transmute(survey_id,
+            cluster_id,
+            res_type,
+            survey_region_id,
+            longitude,
+            latitude,
+            geoloc_area_id = area_id,
+            geoloc_distance = distance)
+
+#' Review clusters outside admin area
+
+survey_clusters %>%
+  filter(geoloc_distance > 0) %>%
+  arrange(-geoloc_distance) %>%
+  left_join(survey_regions)
+
+
+
+#' ## Survey individuals dataset
+
+religion_labels <- c(`1` = "Catholic",
+                     `2` = "Protestant",
+                     `3` = "Muslim",
+                     `4` = "None",
+                     `96` = "Other",
+                     `-8` = "Don't know",
+                     `-9` = "Refused")
+
+ethniccode_labels <- c(`1` = "Bemba",
+                       `2` = "Tonga",
+                       `3` = "Kaonde",
+                       `4` = "Lozi",
+                       `5` = "Lunda",
+                       `6` = "Luvale",
+                       `7` = "Mambwe",
+                       `8` = "Ngoni",
+                       `9` = "Nyanja",
+                       `10` = "Tumbuka",
+                       `11` = "Other",
+                       `99` = "Missing")
+
+mcstatus_lables <- c(`1` = "Yes",
+                     `2` = "No",
+                     `-8` = "Don't know",
+                     `-9` = "Refused")
+
+mcwho_labels = c(`1` = "Doctor, clinical officer, or nurse",
+                 `2` = "Traditional practitioner / circumciser",
+                 `3` = "Midwife",
+                 `96` = "Other",
+                 `-8` = "Don't know",
+                 `-9` = "Refused")
+
+mcwho_recode = c(`1` = "Healthcare worker",
+                 `2` = "Traditional practitioner",
+                 `3` = "Traditional practitioner",   ## TODO: UNSURE ON THIS
+                 `96` = "Traditional practitioner",
+                 `-8` = NA_character_,
+                 `-9` = NA_character_)
+
+
+#' Create individuals data
+
+survey_individuals <-
+  bind_rows(
+    phia %>%
+    transmute(
+      survey_id,
+      cluster_id,
+      individual_id = personid,
+      household = householdid,
+      line = personid,
+      interview_cmc = 12 * (surveystyear - 1900) + surveystmonth,
+      sex = factor(gender, 1:2, c("male", "female")),
+      age,
+      dob_cmc = NA,
+      religion = recode(religion, !!!religion_labels),
+      ethnicity = recode(ethniccode, !!!ethniccode_labels),
+      indweight = intwt0
+    ),
+    chphia %>%
+    transmute(
+      survey_id,
+      cluster_id,
+      individual_id = personid,
+      household = householdid,
+      line = personid,
+      interview_cmc = 12 * (surveystyear - 1900) + surveystmonth,
+      sex = factor(gender, 1:2, c("male", "female")),
+      age,
+      dob_cmc = interview_cmc - agem,
+      indweight = intwt0
+    )
+  ) %>%
+  mutate(age = as.integer(age),
+         indweight = indweight / mean(indweight, na.rm=TRUE))
+
+
+survey_biomarker <-
+  bind_rows(
+    phia %>%
+    filter(!is.na(hivstatusfinal)) %>%
+    transmute(
+      survey_id,
+      individual_id = personid,
+      hivweight = btwt0,
+      hivstatus = case_when(hivstatusfinal == 1 ~ 1,
+                            hivstatusfinal == 2 ~ 0),
+      arv = case_when(arvstatus == 1 ~ 1,
+                      arvstatus == 2 ~ 0),
+      artself = case_when(artselfreported == 1 ~ 1,
+                          artselfreported == 2 ~ 0),
+      vls = case_when(vls == 1 ~ 1,
+                      vls == 2 ~ 0),
+      cd4 = cd4count,
+      recent = case_when(recentlagvlarv == 1 ~ 1,
+                         recentlagvlarv == 2 ~ 0)
+    )
+   ,
+    chphia %>%
+    filter(!is.na(hivstatusfinal)) %>%
+    transmute(
+      survey_id,
+      individual_id = personid,
+      hivweight = btwt0,
+      hivstatus = case_when(hivstatusfinal == 1 ~ 1,
+                            hivstatusfinal == 2 ~ 0),
+      arv = case_when(arvstatus == 1 ~ 1,
+                      arvstatus == 2 ~ 0),
+      artself = case_when(pedartparentreported == 1 ~ 1,
+                          pedartparentreported == 2 ~ 0),
+      vls = case_when(vls == 1 ~ 1,
+                      vls == 2 ~ 0),
+      cd4 = cd4count,
+      recent = case_when(recentlagvlarv == 1 ~ 1,
+                         recentlagvlarv == 2 ~ 0)
+    )
+  ) %>%
+  mutate(hivweight = hivweight / mean(hivweight, na.rm = TRUE))
+
+
+survey_circumcision <- phia %>%
+  filter(gender == 1) %>%
+  transmute(
+    survey_id,
+    individual_id = personid,
+    circumcised = recode(mcstatus, `2` = 0L , `1` = 1L, .default = NA_integer_),
+    circ_age = mcage,
+    circ_where = NA_character_,
+    circ_who = recode(mcwho, !!!mcwho_recode)
+  )
+
+
+
+survey_meta <- survey_individuals %>%
+  group_by(survey_id) %>%
+  summarise(female_age_min = min(if_else(sex == "female", age, NA_integer_), na.rm=TRUE),
+            female_age_max = max(if_else(sex == "female", age, NA_integer_), na.rm=TRUE),
+            male_age_min = min(if_else(sex == "male", age, NA_integer_), na.rm=TRUE),
+            male_age_max = max(if_else(sex == "male", age, NA_integer_), na.rm=TRUE),
+            .groups = "drop") %>%
+  mutate(iso3 = substr(survey_id, 1, 3),
+         country = country,
+         survey_type = "PHIA",
+         survey_mid_calendar_quarter = survey_mid_calendar_quarter,
+         fieldwork_start = NA,
+         fieldwork_end   = NA)
+
+#' ## Save survey datasets
+
+write_csv(survey_meta, paste0(tolower(survey_id), "_survey_meta.csv"), na = "")
+write_csv(survey_regions, paste0(tolower(survey_id), "_survey_regions.csv"), na = "")
+write_csv(survey_clusters, paste0(tolower(survey_id), "_survey_clusters.csv"), na = "")
+write_csv(survey_individuals, paste0(tolower(survey_id), "_survey_individuals.csv"), na = "")
+write_csv(survey_biomarker, paste0(tolower(survey_id), "_survey_biomarker.csv"), na = "")
+write_csv(survey_circumcision, paste0(tolower(survey_id), "_survey_circumcision.csv"), na = "")

--- a/src/zwe_survey_phia/orderly.yml
+++ b/src/zwe_survey_phia/orderly.yml
@@ -1,0 +1,33 @@
+script: script.R
+
+artefacts:
+  - data:
+      description: ZimPHIA 2015-16 survey microdata
+      filenames:
+        - zwe2016phia_survey_meta.csv
+        - zwe2016phia_survey_regions.csv
+        - zwe2016phia_survey_clusters.csv
+        - zwe2016phia_survey_individuals.csv
+        - zwe2016phia_survey_biomarker.csv
+        - zwe2016phia_survey_circumcision.csv
+  - staticgraph:
+      description: Comparison of survey regions and health zones
+      filenames: 
+        - check/compare_survey_regions.png
+
+packages:
+  - dplyr
+  - ggplot2
+  - haven
+  - naomi
+  - spud
+  - rdhs
+  - readr
+  - sf
+
+depends:
+  zwe_data_areas:
+    id: latest
+    use:
+      depends/zwe_areas.geojson: zwe_areas.geojson
+  

--- a/src/zwe_survey_phia/orderly.yml
+++ b/src/zwe_survey_phia/orderly.yml
@@ -10,10 +10,6 @@ artefacts:
         - zwe2016phia_survey_individuals.csv
         - zwe2016phia_survey_biomarker.csv
         - zwe2016phia_survey_circumcision.csv
-  - staticgraph:
-      description: Comparison of survey regions and health zones
-      filenames: 
-        - check/compare_survey_regions.png
 
 packages:
   - dplyr

--- a/src/zwe_survey_phia/script.R
+++ b/src/zwe_survey_phia/script.R
@@ -1,0 +1,389 @@
+
+iso3 <- "ZWE"
+country <- "Zimbabwe"
+survey_id  <- "ZWE2016PHIA"
+survey_mid_calendar_quarter <- "CY2016Q1"
+
+
+#' ## Load area hierarchy
+areas <- read_sf("depends/zwe_areas.geojson")
+
+
+#' ## Load PHIA datasets
+sharepoint <- spud::sharepoint$new("https://imperiallondon.sharepoint.com/")
+
+phia_path <- "sites/HIVInferenceGroup-WP/Shared Documents/Data/household surveys/PHIA"
+
+paths <- list(geo = "datasets/ZWE/datasets/ZIMPHIA 2015-2016 PR Geospatial Data 20211001.zip",
+              hh = "datasets/ZWE/datasets/102_ZIMPHIA 2015-2016 Household Dataset (DTA).zip",
+              ind = "datasets/ZWE/datasets/202_ZIMPHIA 2015-2016 Adult Interview Dataset (DTA).zip",
+              bio = "datasets/ZWE/datasets/302_ZIMPHIA 2015-2016 Adult Biomarker Dataset (DTA).zip",
+              chind = "datasets/ZWE/datasets/205_ZIMPHIA 2015-2016 Child Interview Dataset (DTA).zip",
+              chbio = "datasets/ZWE/datasets/305_ZIMPHIA 2015-2016 Child Biomarker Dataset (DTA).zip") %>%
+  lapply(function(x) file.path(phia_path, x)) %>%
+  lapply(URLencode)
+
+phia_files <- lapply(paths, sharepoint$download)
+
+geo <- rdhs::read_zipdata(phia_files$geo)
+
+hh <- rdhs::read_zipdata(phia_files$hh)
+bio <- rdhs::read_zipdata(phia_files$bio)
+ind <- rdhs::read_zipdata(phia_files$ind)
+chbio <- rdhs::read_zipdata(phia_files$chbio)
+chind <- rdhs::read_zipdata(phia_files$chind)
+
+phia <- ind %>%
+  filter(indstatus == 1) %>%  # Respondent
+  select(varstrat, varunit, province, urban, householdid,
+         personid, surveystyear, surveystmonth,
+         intwt0, gender, age, religion,
+         mcstatus, mcage, mcwho) %>%
+  full_join(
+    bio %>%
+    filter(bt_status == 1) %>%
+    select(personid, btwt0, hivstatusfinal, arvstatus, artselfreported,
+           vls, cd4count, recentlagvlarv),
+    by = "personid"
+  ) %>%
+  mutate(survey_id = survey_id,
+         cluster_id = paste(varstrat, varunit))
+
+
+#' Note: Religion and ethnic group were not asked for children. Strategy to
+#'       assign these based on `momid` if available, otherwise modal value
+#'       from the household. But the primary motivation for these variables
+#'       is for circumcision analysis, which is not asked for children.
+#' 
+
+chphia <- chind %>%
+  filter(indstatus == 1) %>%
+  select(varstrat, varunit, province, urban, householdid,
+         personid, surveystyear, surveystmonth,
+         intwt0, gender, age, agem) %>%
+  full_join(
+    chbio %>%
+    filter(bt_status == 1) %>%
+    select(personid, btwt0, hivstatusfinal, arvstatus, pedartparentreported,
+           vls, cd4count, recentlagvlarv),
+    by = "personid"
+  ) %>%
+  mutate(survey_id = survey_id,
+         cluster_id = paste(varstrat, varunit))
+
+
+
+#' ## Survey regions
+#'
+#' This table identifies the smallest area in the area hierarchy which contains each
+#' region in the survey stratification, which is the smallest area to which a cluster
+#' can be assigned with certainty.
+
+hh$survey_region_id <- hh$province # different in each survey dataset depending on survey stratification
+
+survey_region_id <- c("Bulawayo" = 0,
+                      "Manicaland" = 1,
+                      "Mashonaland Central" = 2,
+                      "Mashonaland East" = 3,
+                      "Mashonaland West" = 4,
+                      "Matabeleland North" = 5,
+                      "Matabeleland South" = 6,
+                      "Midlands" = 7,
+                      "Masvingo" = 8,
+                      "Harare" = 9)
+
+areas %>% filter(area_level == 1) %>% select(area_id, area_name)
+
+survey_region_area_id <- c("Bulawayo" = "ZWE_1_10",
+                           "Manicaland" = "ZWE_1_12",
+                           "Mashonaland Central" = "ZWE_1_13",
+                           "Mashonaland East" = "ZWE_1_14",
+                           "Mashonaland West" = "ZWE_1_15",
+                           "Matabeleland North" = "ZWE_1_17",
+                           "Matabeleland South" = "ZWE_1_18",
+                           "Midlands" = "ZWE_1_19",
+                           "Masvingo" = "ZWE_1_16",
+                           "Harare" = "ZWE_1_11")
+
+survey_regions <- tibble(survey_id = survey_id,
+                         survey_region_id = survey_region_id,
+                         survey_region_name = names(survey_region_id),
+                         survey_region_area_id = survey_region_area_id[names(survey_region_id)])
+
+
+#' Inspect area_id assigments to confirm
+
+survey_regions %>%
+  left_join(
+    areas %>%
+    as.data.frame() %>%
+    select(area_id, area_name, area_level, area_level_label),
+    by = c("survey_region_area_id" = "area_id")
+  )
+
+
+#' Add survey region boundary 
+
+survey_regions <- survey_regions %>%
+  left_join(
+    spread_areas(as.data.frame(areas)) %>%
+    left_join(select(areas, area_id), by = "area_id") %>%
+    st_as_sf() %>%
+    group_by(survey_region_name) %>%
+    summarise(.groups = "drop"),
+    by = "survey_region_name"
+  ) %>%
+  st_as_sf()
+
+
+p_check_survey_regions <- ggplot(survey_regions) +
+  geom_sf(aes(fill = survey_region_name), color = "grey60", alpha = 0.6) +
+  geom_sf(data = areas %>% filter(area_level == 2), fill = NA, inherit.aes = FALSE) +
+  ggtitle("Survey regions and health provinces (black lines)",
+          "Mulange is in South West in MPHIA but South East\nin MoH classification") +
+  naomi::th_map()
+
+dir.create("check")
+ggsave("check/compare_survey_regions.png", p_check_survey_regions, h=5, w=4)
+
+
+#' Inspect area_id assigments to confirm
+
+survey_regions %>%
+  left_join(
+    areas %>%
+    as.data.frame() %>%
+    select(area_id, area_name, area_level, area_level_label),
+    by = c("survey_region_area_id" = "area_id")
+  ) %>%
+  st_drop_geometry() %>%
+  select(survey_region_name, area_name, area_level_label)
+
+
+#' *** Should not require edits beyond this point ***
+
+#' ## Survey clusters dataset
+#'
+#' This data frame maps survey clusters to the highest level in the area hiearchy
+#' based on geomasked cluster centroids, additionally checking that the geolocated
+#' areas are contained in the survey region.
+
+survey_clusters <- hh %>%
+  transmute(survey_id = survey_id,
+            cluster_id = paste(varstrat, varunit),
+            cluster_id,
+            res_type = factor(urban, 1:2, c("urban", "rural")),
+            survey_region_id,
+            centroidid) %>%
+  distinct() %>%
+  left_join(geo, by = "centroidid") %>%
+  select(-centroidid) %>%
+  sf::st_as_sf(coords = c("longitude", "latitude"), remove = FALSE) %>%
+  sf::`st_crs<-`(4326)
+
+
+#' Snap clusters to areas
+#' 
+#' This is slow because it maps to the lowest level immediately
+#' It would be more efficient to do this recursively through
+#' the location hierarchy tree -- but not worth the effort right now.
+
+#' Create a list of all of the areas within each survey region
+#' (These are the candidate areas where a cluster could be located)
+
+survey_region_areas  <- survey_regions %>%
+  left_join(
+    get_area_collection(as.data.frame(areas),
+                        area_scope = survey_regions$survey_region_area_id),
+    by = c("survey_region_area_id" = "area_scope")
+  ) %>%
+  left_join(
+    areas %>% select(area_id, geometry),
+    by = "area_id"
+  ) %>%
+  select(survey_region_id, area_id, geometry_area = geometry)
+
+#' Calculate distance to each candidate area for each cluster
+
+survey_clusters <- survey_clusters %>%
+  left_join(survey_region_areas, by = "survey_region_id") %>%
+  mutate(
+    distance = unlist(Map(sf::st_distance, geometry, geometry_area))
+  )
+
+#' Keep the area with the smallest distance from cluster centroid.
+#' (Should be 0 for almost all)
+
+survey_clusters <- survey_clusters %>%
+  arrange(distance) %>%
+  group_by(survey_id, cluster_id) %>%
+  filter(row_number() == 1) %>%
+  ungroup() %>%
+  as.data.frame() %>%
+  transmute(survey_id,
+            cluster_id,
+            res_type,
+            survey_region_id,
+            longitude,
+            latitude,
+            geoloc_area_id = area_id,
+            geoloc_distance = distance)
+
+#' Review clusters outside admin area
+
+survey_clusters %>%
+  filter(geoloc_distance > 0) %>%
+  arrange(-geoloc_distance) %>%
+  left_join(survey_regions) 
+
+
+
+#' ## Survey individuals dataset
+
+religion_labels <- c(`1` = "Traditional",
+                     `2` = "Roman Catholic",
+                     `3` = "Protestant",
+                     `4` = "Pentecostal",
+                     `5` = "Apostolic Sect.",
+                     `6` = "Other Christian",
+                     `7` = "Muslim",
+                     `8` = "No religion",
+                     `96` = "Other",
+                     `-8` = "Don't know",
+                     `-9` = "Refused")
+
+
+mcstatus_lables <- c(`1` = "Yes",
+                     `2` = "No",
+                     `-8` = "Don't know",
+                     `-9` = "Refused")
+
+mcwho_labels = c(`1` = "Doctor, clinical officer, or nurse",
+                 `2` = "Traditional practitioner / circumciser",
+                 `3` = "Midwife",
+                 `96` = "Other",
+                 `-8` = "Don't know",
+                 `-9` = "Refused")
+
+mcwho_recode = c(`1` = "Healthcare worker",
+                 `2` = "Traditional practitioner",
+                 `3` = "Traditional practitioner",   ## TODO: UNSURE ON THIS
+                 `96` = "Traditional practitioner",
+                 `-8` = NA_character_,
+                 `-9` = NA_character_)
+
+
+#' Create individuals data
+
+survey_individuals <-
+  bind_rows(
+    phia %>%
+    transmute(
+      survey_id,
+      cluster_id,
+      individual_id = personid,
+      household = householdid,
+      line = personid,
+      interview_cmc = 12 * (surveystyear - 1900) + surveystmonth,
+      sex = factor(gender, 1:2, c("male", "female")),
+      age,
+      dob_cmc = NA,
+      religion = recode(religion, !!!religion_labels),
+      indweight = intwt0
+    ),
+    chphia %>%
+    transmute(
+      survey_id,
+      cluster_id,
+      individual_id = personid,
+      household = householdid,
+      line = personid,
+      interview_cmc = 12 * (surveystyear - 1900) + surveystmonth,
+      sex = factor(gender, 1:2, c("male", "female")),
+      age,
+      dob_cmc = interview_cmc - agem,
+      indweight = intwt0
+    )
+  ) %>%
+  mutate(age = as.integer(age),
+         indweight = indweight / mean(indweight, na.rm=TRUE)) 
+
+
+survey_biomarker <-
+  bind_rows(
+    phia %>%
+    filter(!is.na(hivstatusfinal)) %>%
+    transmute(
+      survey_id,
+      individual_id = personid,
+      hivweight = btwt0,
+      hivstatus = case_when(hivstatusfinal == 1 ~ 1,
+                            hivstatusfinal == 2 ~ 0),
+      arv = case_when(arvstatus == 1 ~ 1,
+                      arvstatus == 2 ~ 0),
+      artself = case_when(artselfreported == 1 ~ 1,
+                          artselfreported == 2 ~ 0),
+      vls = case_when(vls == 1 ~ 1,
+                      vls == 2 ~ 0),
+      cd4 = cd4count,
+      recent = case_when(recentlagvlarv == 1 ~ 1,
+                         recentlagvlarv == 2 ~ 0)
+    )
+   ,
+    chphia %>%
+    filter(!is.na(hivstatusfinal)) %>%
+    transmute(
+      survey_id,
+      individual_id = personid,
+      hivweight = btwt0,
+      hivstatus = case_when(hivstatusfinal == 1 ~ 1,
+                            hivstatusfinal == 2 ~ 0),
+      arv = case_when(arvstatus == 1 ~ 1,
+                      arvstatus == 2 ~ 0),
+      artself = case_when(pedartparentreported == 1 ~ 1,
+                          pedartparentreported == 2 ~ 0),
+      vls = case_when(vls == 1 ~ 1,
+                      vls == 2 ~ 0),
+      cd4 = cd4count,
+      recent = case_when(recentlagvlarv == 1 ~ 1,
+                         recentlagvlarv == 2 ~ 0)
+    )
+  ) %>%
+  mutate(hivweight = hivweight / mean(hivweight, na.rm = TRUE))
+
+
+survey_circumcision <- phia %>%
+  filter(gender == 1) %>%
+  transmute(
+    survey_id,
+    individual_id = personid,
+    circumcised = recode(mcstatus, `2` = 0L , `1` = 1L, .default = NA_integer_),
+    circ_age = mcage,
+    circ_where = NA_character_,
+    circ_who = recode(mcwho, !!!mcwho_recode)
+  )
+
+
+
+survey_meta <- survey_individuals %>%
+  group_by(survey_id) %>%
+  summarise(female_age_min = min(if_else(sex == "female", age, NA_integer_), na.rm=TRUE),
+            female_age_max = max(if_else(sex == "female", age, NA_integer_), na.rm=TRUE),
+            male_age_min = min(if_else(sex == "male", age, NA_integer_), na.rm=TRUE),
+            male_age_max = max(if_else(sex == "male", age, NA_integer_), na.rm=TRUE),
+            .groups = "drop") %>%
+  mutate(iso3 = substr(survey_id, 1, 3),
+         country = country,
+         survey_type = "PHIA",
+         survey_mid_calendar_quarter = survey_mid_calendar_quarter,
+         fieldwork_start = NA,
+         fieldwork_end   = NA)
+
+#' ## Save survey datasets
+
+write_csv(survey_meta, paste0(tolower(survey_id), "_survey_meta.csv"), na = "")
+write_csv(survey_regions, paste0(tolower(survey_id), "_survey_regions.csv"), na = "")
+write_csv(survey_clusters, paste0(tolower(survey_id), "_survey_clusters.csv"), na = "")
+write_csv(survey_individuals, paste0(tolower(survey_id), "_survey_individuals.csv"), na = "")
+write_csv(survey_biomarker, paste0(tolower(survey_id), "_survey_biomarker.csv"), na = "")
+write_csv(survey_circumcision, paste0(tolower(survey_id), "_survey_circumcision.csv"), na = "")

--- a/src/zwe_survey_phia/script.R
+++ b/src/zwe_survey_phia/script.R
@@ -35,7 +35,7 @@ chind <- rdhs::read_zipdata(phia_files$chind)
 
 phia <- ind %>%
   filter(indstatus == 1) %>%  # Respondent
-  select(varstrat, varunit, province, urban, householdid,
+  select(centroidid, province, urban, householdid,
          personid, surveystyear, surveystmonth,
          intwt0, gender, age, religion,
          mcstatus, mcage, mcwho) %>%
@@ -47,7 +47,7 @@ phia <- ind %>%
     by = "personid"
   ) %>%
   mutate(survey_id = survey_id,
-         cluster_id = paste(varstrat, varunit))
+         cluster_id = centroidid)
 
 
 #' Note: Religion and ethnic group were not asked for children. Strategy to
@@ -58,7 +58,7 @@ phia <- ind %>%
 
 chphia <- chind %>%
   filter(indstatus == 1) %>%
-  select(varstrat, varunit, province, urban, householdid,
+  select(centroidid, province, urban, householdid,
          personid, surveystyear, surveystmonth,
          intwt0, gender, age, agem) %>%
   full_join(
@@ -69,7 +69,7 @@ chphia <- chind %>%
     by = "personid"
   ) %>%
   mutate(survey_id = survey_id,
-         cluster_id = paste(varstrat, varunit))
+         cluster_id = centroidid)
 
 
 
@@ -141,14 +141,12 @@ survey_regions %>%
 
 survey_clusters <- hh %>%
   transmute(survey_id = survey_id,
-            cluster_id = paste(varstrat, varunit),
+            cluster_id = centroidid,
             cluster_id,
             res_type = factor(urban, 1:2, c("urban", "rural")),
-            survey_region_id,
-            centroidid) %>%
+            survey_region_id) %>%
   distinct() %>%
-  left_join(geo, by = "centroidid") %>%
-  select(-centroidid) %>%
+  left_join(geo, by = c("cluster_id" = "centroidid")) %>%
   sf::st_as_sf(coords = c("longitude", "latitude"), remove = FALSE) %>%
   sf::`st_crs<-`(4326)
 


### PR DESCRIPTION
This adds PHIA datasets for the following: CIV, CMR, LSO, MWI, NAM, RWA, SWZ, TZA, UGA, ZMB, ZWE

ETH is not created due to urban-only sampling frame.

This creates the following datasets:
* survey_meta
* survey_regions
* survey_clusters
* survey_individuals
* survey_biomarker
* survey_circumcision

The `centroidid` variable is used for `cluster_id`.

Edit: I have just added two more commits to this PR to (1) add RWA2019DHS and (2) add TZA2007AIS and TZA2012AIS.